### PR TITLE
feat(x/fibre): `ValidateBasic` methods

### DIFF
--- a/x/fibre/types/msgs.go
+++ b/x/fibre/types/msgs.go
@@ -1,0 +1,194 @@
+package types
+
+import (
+	"fmt"
+
+	errorsmod "cosmossdk.io/errors"
+	"github.com/celestiaorg/go-square/v2/share"
+	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+)
+
+// ValidateBasic performs stateless validation for MsgDepositToEscrow
+func (msg *MsgDepositToEscrow) ValidateBasic() error {
+	// Validate signer address
+	if _, err := sdk.AccAddressFromBech32(msg.Signer); err != nil {
+		return errorsmod.Wrapf(sdkerrors.ErrInvalidAddress, "invalid signer address: %s", err)
+	}
+
+	// Validate amount is valid and positive
+	if !msg.Amount.IsValid() {
+		return errorsmod.Wrap(sdkerrors.ErrInvalidCoins, msg.Amount.String())
+	}
+
+	if !msg.Amount.IsPositive() {
+		return errorsmod.Wrap(sdkerrors.ErrInvalidCoins, "amount must be positive")
+	}
+
+	return nil
+}
+
+// ValidateBasic performs stateless validation for MsgRequestWithdrawal
+func (msg *MsgRequestWithdrawal) ValidateBasic() error {
+	// Validate signer address
+	if _, err := sdk.AccAddressFromBech32(msg.Signer); err != nil {
+		return errorsmod.Wrapf(sdkerrors.ErrInvalidAddress, "invalid signer address: %s", err)
+	}
+
+	// Validate amount is valid and positive
+	if !msg.Amount.IsValid() {
+		return errorsmod.Wrap(sdkerrors.ErrInvalidCoins, msg.Amount.String())
+	}
+
+	if !msg.Amount.IsPositive() {
+		return errorsmod.Wrap(sdkerrors.ErrInvalidCoins, "amount must be positive")
+	}
+
+	return nil
+}
+
+// ValidateBasic performs stateless validation for PaymentPromise
+func (msg *PaymentPromise) ValidateBasic() error {
+	// Validate signer_public_key is a valid public key
+	if msg.SignerPublicKey == nil {
+		return errorsmod.Wrap(sdkerrors.ErrInvalidPubKey, "signer public key cannot be nil")
+	}
+
+	pubKey, ok := msg.SignerPublicKey.GetCachedValue().(cryptotypes.PubKey)
+	if !ok {
+		return errorsmod.Wrap(sdkerrors.ErrInvalidPubKey, "failed to get cached public key")
+	}
+
+	if pubKey == nil {
+		return errorsmod.Wrap(sdkerrors.ErrInvalidPubKey, "signer public key cannot be nil")
+	}
+
+	// Validate namespace
+	if len(msg.Namespace) == 0 {
+		return errorsmod.Wrap(sdkerrors.ErrInvalidRequest, "namespace cannot be empty")
+	}
+
+	// Validate namespace format (29 bytes total)
+	if len(msg.Namespace) != share.NamespaceSize {
+		return errorsmod.Wrapf(sdkerrors.ErrInvalidRequest, "namespace must be %d bytes, got %d", share.NamespaceSize, len(msg.Namespace))
+	}
+
+	// Parse and validate namespace
+	ns, err := share.NewNamespaceFromBytes(msg.Namespace)
+	if err != nil {
+		return errorsmod.Wrapf(sdkerrors.ErrInvalidRequest, "invalid namespace: %s", err)
+	}
+
+	// Check if namespace is reserved (not allowed for user blobs)
+	if err := ValidateBlobNamespace(ns); err != nil {
+		return errorsmod.Wrapf(sdkerrors.ErrInvalidRequest, "invalid blob namespace: %s", err)
+	}
+
+	// Validate blob_size is positive
+	if msg.BlobSize == 0 {
+		return errorsmod.Wrap(sdkerrors.ErrInvalidRequest, "blob size must be positive")
+	}
+
+	// Validate commitment is 32 bytes
+	if len(msg.Commitment) != 32 {
+		return errorsmod.Wrapf(sdkerrors.ErrInvalidRequest, "commitment must be 32 bytes, got %d", len(msg.Commitment))
+	}
+
+	// Validate row_version is supported
+	if msg.RowVersion != uint32(share.ShareVersionZero) && msg.RowVersion != uint32(share.ShareVersionOne) {
+		return errorsmod.Wrapf(sdkerrors.ErrInvalidRequest, "unsupported row version: %d", msg.RowVersion)
+	}
+
+	// Validate height is positive
+	if msg.Height <= 0 {
+		return errorsmod.Wrap(sdkerrors.ErrInvalidRequest, "height must be positive")
+	}
+
+	// Validate creation_timestamp is not zero
+	if msg.CreationTimestamp.IsZero() {
+		return errorsmod.Wrap(sdkerrors.ErrInvalidRequest, "creation timestamp cannot be zero")
+	}
+
+	// Validate signature is properly formatted and non-empty
+	if len(msg.Signature) == 0 {
+		return errorsmod.Wrap(sdkerrors.ErrInvalidRequest, "signature cannot be empty")
+	}
+
+	// Validate chain_id is not empty
+	if msg.ChainId == "" {
+		return errorsmod.Wrap(sdkerrors.ErrInvalidRequest, "chain ID cannot be empty")
+	}
+
+	return nil
+}
+
+// ValidateBasic performs stateless validation for MsgPayForFibre
+func (msg *MsgPayForFibre) ValidateBasic() error {
+	// Validate signer address
+	if _, err := sdk.AccAddressFromBech32(msg.Signer); err != nil {
+		return errorsmod.Wrapf(sdkerrors.ErrInvalidAddress, "invalid signer address: %s", err)
+	}
+
+	// Validate PaymentPromise
+	if err := msg.PaymentPromise.ValidateBasic(); err != nil {
+		return errorsmod.Wrap(err, "invalid payment promise")
+	}
+
+	// Must have at least one validator signature
+	if len(msg.ValidatorSignatures) == 0 {
+		return errorsmod.Wrap(sdkerrors.ErrInvalidRequest, "must have at least one validator signature")
+	}
+
+	// All validator signatures must be properly formatted (non-empty)
+	for i, sig := range msg.ValidatorSignatures {
+		if len(sig) == 0 {
+			return errorsmod.Wrapf(sdkerrors.ErrInvalidRequest, "validator signature at index %d cannot be empty", i)
+		}
+	}
+
+	return nil
+}
+
+// ValidateBasic performs stateless validation for MsgPaymentPromiseTimeout
+func (msg *MsgPaymentPromiseTimeout) ValidateBasic() error {
+	// Validate signer address (can be anyone)
+	if _, err := sdk.AccAddressFromBech32(msg.Signer); err != nil {
+		return errorsmod.Wrapf(sdkerrors.ErrInvalidAddress, "invalid signer address: %s", err)
+	}
+
+	// Validate PaymentPromise (including signature validation)
+	if err := msg.PaymentPromise.ValidateBasic(); err != nil {
+		return errorsmod.Wrap(err, "invalid payment promise")
+	}
+
+	return nil
+}
+
+// ValidateBasic performs stateless validation for MsgUpdateFibreParams
+func (msg *MsgUpdateFibreParams) ValidateBasic() error {
+	// Validate authority address
+	if _, err := sdk.AccAddressFromBech32(msg.Authority); err != nil {
+		return errorsmod.Wrapf(sdkerrors.ErrInvalidAddress, "invalid authority address: %s", err)
+	}
+
+	// Validate params
+	if err := msg.Params.Validate(); err != nil {
+		return errorsmod.Wrap(err, "invalid params")
+	}
+
+	return nil
+}
+
+// ValidateBlobNamespace validates that a namespace is suitable for blob data
+// This is adapted from the blob module's validation logic
+func ValidateBlobNamespace(ns share.Namespace) error {
+	if ns.IsReserved() {
+		return fmt.Errorf("namespace %s is reserved", ns)
+	}
+
+	// Additional validation can be added here if needed
+	// The IsReserved() check above covers the main validation requirements
+
+	return nil
+}

--- a/x/fibre/types/msgs.go
+++ b/x/fibre/types/msgs.go
@@ -1,8 +1,6 @@
 package types
 
 import (
-	"fmt"
-
 	errorsmod "cosmossdk.io/errors"
 	"github.com/celestiaorg/go-square/v2/share"
 	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
@@ -76,7 +74,7 @@ func (msg *PaymentPromise) ValidateBasic() error {
 		return errorsmod.Wrapf(sdkerrors.ErrInvalidRequest, "invalid namespace: %s", err)
 	}
 
-	if err := ValidateBlobNamespace(namespace); err != nil {
+	if err := namespace.ValidateForBlob(); err != nil {
 		return errorsmod.Wrapf(sdkerrors.ErrInvalidRequest, "invalid blob namespace: %s", err)
 	}
 
@@ -158,19 +156,6 @@ func (msg *MsgUpdateFibreParams) ValidateBasic() error {
 	if err := msg.Params.Validate(); err != nil {
 		return errorsmod.Wrap(err, "invalid params")
 	}
-
-	return nil
-}
-
-// ValidateBlobNamespace validates that a namespace is suitable for blob data
-// This is adapted from the blob module's validation logic
-func ValidateBlobNamespace(ns share.Namespace) error {
-	if ns.IsReserved() {
-		return fmt.Errorf("namespace %s is reserved", ns)
-	}
-
-	// Additional validation can be added here if needed
-	// The IsReserved() check above covers the main validation requirements
 
 	return nil
 }

--- a/x/fibre/types/msgs.go
+++ b/x/fibre/types/msgs.go
@@ -136,12 +136,10 @@ func (msg *MsgPayForFibre) ValidateBasic() error {
 
 // ValidateBasic performs stateless validation for MsgPaymentPromiseTimeout
 func (msg *MsgPaymentPromiseTimeout) ValidateBasic() error {
-	// Validate signer address (can be anyone)
 	if _, err := sdk.AccAddressFromBech32(msg.Signer); err != nil {
 		return errorsmod.Wrapf(sdkerrors.ErrInvalidAddress, "invalid signer address: %s", err)
 	}
 
-	// Validate PaymentPromise (including signature validation)
 	if err := msg.PaymentPromise.ValidateBasic(); err != nil {
 		return errorsmod.Wrap(err, "invalid payment promise")
 	}

--- a/x/fibre/types/msgs.go
+++ b/x/fibre/types/msgs.go
@@ -113,24 +113,20 @@ func (msg *PaymentPromise) ValidateBasic() error {
 
 // ValidateBasic performs stateless validation for MsgPayForFibre
 func (msg *MsgPayForFibre) ValidateBasic() error {
-	// Validate signer address
 	if _, err := sdk.AccAddressFromBech32(msg.Signer); err != nil {
 		return errorsmod.Wrapf(sdkerrors.ErrInvalidAddress, "invalid signer address: %s", err)
 	}
 
-	// Validate PaymentPromise
 	if err := msg.PaymentPromise.ValidateBasic(); err != nil {
 		return errorsmod.Wrap(err, "invalid payment promise")
 	}
 
-	// Must have at least one validator signature
 	if len(msg.ValidatorSignatures) == 0 {
 		return errorsmod.Wrap(sdkerrors.ErrInvalidRequest, "must have at least one validator signature")
 	}
 
-	// All validator signatures must be properly formatted (non-empty)
-	for i, sig := range msg.ValidatorSignatures {
-		if len(sig) == 0 {
+	for i, signature := range msg.ValidatorSignatures {
+		if len(signature) == 0 {
 			return errorsmod.Wrapf(sdkerrors.ErrInvalidRequest, "validator signature at index %d cannot be empty", i)
 		}
 	}

--- a/x/fibre/types/msgs.go
+++ b/x/fibre/types/msgs.go
@@ -12,12 +12,10 @@ import (
 
 // ValidateBasic performs stateless validation for MsgDepositToEscrow
 func (msg *MsgDepositToEscrow) ValidateBasic() error {
-	// Validate signer address
 	if _, err := sdk.AccAddressFromBech32(msg.Signer); err != nil {
 		return errorsmod.Wrapf(sdkerrors.ErrInvalidAddress, "invalid signer address: %s", err)
 	}
 
-	// Validate amount is valid and positive
 	if !msg.Amount.IsValid() {
 		return errorsmod.Wrap(sdkerrors.ErrInvalidCoins, msg.Amount.String())
 	}

--- a/x/fibre/types/msgs.go
+++ b/x/fibre/types/msgs.go
@@ -29,12 +29,10 @@ func (msg *MsgDepositToEscrow) ValidateBasic() error {
 
 // ValidateBasic performs stateless validation for MsgRequestWithdrawal
 func (msg *MsgRequestWithdrawal) ValidateBasic() error {
-	// Validate signer address
 	if _, err := sdk.AccAddressFromBech32(msg.Signer); err != nil {
 		return errorsmod.Wrapf(sdkerrors.ErrInvalidAddress, "invalid signer address: %s", err)
 	}
 
-	// Validate amount is valid and positive
 	if !msg.Amount.IsValid() {
 		return errorsmod.Wrap(sdkerrors.ErrInvalidCoins, msg.Amount.String())
 	}

--- a/x/fibre/types/msgs.go
+++ b/x/fibre/types/msgs.go
@@ -86,7 +86,7 @@ func (msg *PaymentPromise) ValidateBasic() error {
 		return errorsmod.Wrapf(sdkerrors.ErrInvalidRequest, "commitment must be 32 bytes, got %d", len(msg.Commitment))
 	}
 
-	if err := ValidateRowVersion(msg.RowVersion); err != nil {
+	if err := validateRowVersion(msg.RowVersion); err != nil {
 		return errorsmod.Wrapf(sdkerrors.ErrInvalidRequest, "invalid row version: %s", err)
 	}
 
@@ -147,12 +147,10 @@ func (msg *MsgPaymentPromiseTimeout) ValidateBasic() error {
 
 // ValidateBasic performs stateless validation for MsgUpdateFibreParams
 func (msg *MsgUpdateFibreParams) ValidateBasic() error {
-	// Validate authority address
 	if _, err := sdk.AccAddressFromBech32(msg.Authority); err != nil {
 		return errorsmod.Wrapf(sdkerrors.ErrInvalidAddress, "invalid authority address: %s", err)
 	}
 
-	// Validate params
 	if err := msg.Params.Validate(); err != nil {
 		return errorsmod.Wrap(err, "invalid params")
 	}
@@ -160,7 +158,7 @@ func (msg *MsgUpdateFibreParams) ValidateBasic() error {
 	return nil
 }
 
-func ValidateRowVersion(rowVersion uint32) error {
+func validateRowVersion(rowVersion uint32) error {
 	if rowVersion != RowVersionZero {
 		return errorsmod.Wrapf(sdkerrors.ErrInvalidRequest, "unsupported row version: %d", rowVersion)
 	}

--- a/x/fibre/types/msgs.go
+++ b/x/fibre/types/msgs.go
@@ -48,17 +48,8 @@ func (msg *MsgRequestWithdrawal) ValidateBasic() error {
 
 // ValidateBasic performs stateless validation for PaymentPromise
 func (msg *PaymentPromise) ValidateBasic() error {
-	if msg.SignerPublicKey == nil {
-		return errorsmod.Wrap(sdkerrors.ErrInvalidPubKey, "signer public key cannot be nil")
-	}
-
-	pubKey, ok := msg.SignerPublicKey.GetCachedValue().(cryptotypes.PubKey)
-	if !ok {
-		return errorsmod.Wrap(sdkerrors.ErrInvalidPubKey, "failed to get cached public key")
-	}
-
-	if pubKey == nil {
-		return errorsmod.Wrap(sdkerrors.ErrInvalidPubKey, "signer public key cannot be nil")
+	if msg.ChainId == "" {
+		return errorsmod.Wrap(sdkerrors.ErrInvalidRequest, "chain ID cannot be empty")
 	}
 
 	if len(msg.Namespace) == 0 {
@@ -98,12 +89,21 @@ func (msg *PaymentPromise) ValidateBasic() error {
 		return errorsmod.Wrap(sdkerrors.ErrInvalidRequest, "creation timestamp cannot be zero")
 	}
 
-	if len(msg.Signature) == 0 {
-		return errorsmod.Wrap(sdkerrors.ErrInvalidRequest, "signature cannot be empty")
+	if msg.SignerPublicKey == nil {
+		return errorsmod.Wrap(sdkerrors.ErrInvalidPubKey, "signer public key cannot be nil")
 	}
 
-	if msg.ChainId == "" {
-		return errorsmod.Wrap(sdkerrors.ErrInvalidRequest, "chain ID cannot be empty")
+	pubKey, ok := msg.SignerPublicKey.GetCachedValue().(cryptotypes.PubKey)
+	if !ok {
+		return errorsmod.Wrap(sdkerrors.ErrInvalidPubKey, "failed to get cached public key")
+	}
+
+	if pubKey == nil {
+		return errorsmod.Wrap(sdkerrors.ErrInvalidPubKey, "signer public key cannot be nil")
+	}
+
+	if len(msg.Signature) == 0 {
+		return errorsmod.Wrap(sdkerrors.ErrInvalidRequest, "signature cannot be empty")
 	}
 
 	return nil

--- a/x/fibre/types/msgs_test.go
+++ b/x/fibre/types/msgs_test.go
@@ -1,0 +1,556 @@
+package types
+
+import (
+	"testing"
+	"time"
+
+	"cosmossdk.io/math"
+	"github.com/celestiaorg/go-square/v2/share"
+	"github.com/cosmos/cosmos-sdk/codec/types"
+	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMsgDepositToEscrow_ValidateBasic(t *testing.T) {
+	validAddr := "cosmos1qypqxpq9qcrsszg2pvxq6rs0zqg3yyc5lzv7xu"
+	validCoin := sdk.NewCoin("utia", math.NewInt(1000))
+	zeroCoin := sdk.NewCoin("utia", math.NewInt(0))
+
+	tests := []struct {
+		name    string
+		msg     *MsgDepositToEscrow
+		wantErr bool
+		errType error
+	}{
+		{
+			name: "valid message",
+			msg: &MsgDepositToEscrow{
+				Signer: validAddr,
+				Amount: validCoin,
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid signer address",
+			msg: &MsgDepositToEscrow{
+				Signer: "invalid-address",
+				Amount: validCoin,
+			},
+			wantErr: true,
+			errType: sdkerrors.ErrInvalidAddress,
+		},
+		{
+			name: "empty signer address",
+			msg: &MsgDepositToEscrow{
+				Signer: "",
+				Amount: validCoin,
+			},
+			wantErr: true,
+			errType: sdkerrors.ErrInvalidAddress,
+		},
+		{
+			name: "zero amount",
+			msg: &MsgDepositToEscrow{
+				Signer: validAddr,
+				Amount: zeroCoin,
+			},
+			wantErr: true,
+			errType: sdkerrors.ErrInvalidCoins,
+		},
+		{
+			name: "negative amount",
+			msg: &MsgDepositToEscrow{
+				Signer: validAddr,
+				Amount: sdk.Coin{Denom: "utia", Amount: math.NewInt(-100)},
+			},
+			wantErr: true,
+			errType: sdkerrors.ErrInvalidCoins,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.msg.ValidateBasic()
+			if tt.wantErr {
+				require.Error(t, err)
+				if tt.errType != nil {
+					assert.Contains(t, err.Error(), tt.errType.Error())
+				}
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestMsgRequestWithdrawal_ValidateBasic(t *testing.T) {
+	validAddr := "cosmos1qypqxpq9qcrsszg2pvxq6rs0zqg3yyc5lzv7xu"
+	validCoin := sdk.NewCoin("utia", math.NewInt(1000))
+	zeroCoin := sdk.NewCoin("utia", math.NewInt(0))
+
+	tests := []struct {
+		name    string
+		msg     *MsgRequestWithdrawal
+		wantErr bool
+		errType error
+	}{
+		{
+			name: "valid message",
+			msg: &MsgRequestWithdrawal{
+				Signer: validAddr,
+				Amount: validCoin,
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid signer address",
+			msg: &MsgRequestWithdrawal{
+				Signer: "invalid-address",
+				Amount: validCoin,
+			},
+			wantErr: true,
+			errType: sdkerrors.ErrInvalidAddress,
+		},
+		{
+			name: "zero amount",
+			msg: &MsgRequestWithdrawal{
+				Signer: validAddr,
+				Amount: zeroCoin,
+			},
+			wantErr: true,
+			errType: sdkerrors.ErrInvalidCoins,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.msg.ValidateBasic()
+			if tt.wantErr {
+				require.Error(t, err)
+				if tt.errType != nil {
+					assert.Contains(t, err.Error(), tt.errType.Error())
+				}
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestPaymentPromise_ValidateBasic(t *testing.T) {
+	// Create a valid public key
+	privKey := secp256k1.GenPrivKey()
+	pubKey := privKey.PubKey()
+	pubKeyAny, err := types.NewAnyWithValue(pubKey)
+	require.NoError(t, err)
+
+	// Create a valid namespace (version 0 with 18 leading zeros)
+	validNamespace := make([]byte, share.NamespaceSize)
+	validNamespace[0] = 0 // version 0
+	// bytes 1-18 are already zero (18 leading zeros for version 0)
+	// Set bytes 19-28 to create a valid user namespace
+	for i := 19; i < share.NamespaceSize; i++ {
+		validNamespace[i] = 1
+	}
+
+	validCommitment := make([]byte, 32)
+	for i := range validCommitment {
+		validCommitment[i] = byte(i)
+	}
+
+	tests := []struct {
+		name    string
+		msg     *PaymentPromise
+		wantErr bool
+		errType error
+	}{
+		{
+			name: "valid payment promise",
+			msg: &PaymentPromise{
+				SignerPublicKey:   pubKeyAny,
+				Namespace:         validNamespace,
+				BlobSize:          1000,
+				Commitment:        validCommitment,
+				RowVersion:        uint32(share.ShareVersionZero),
+				CreationTimestamp: time.Now(),
+				Signature:         []byte("valid-signature"),
+				Height:            100,
+				ChainId:           "celestia-test",
+			},
+			wantErr: false,
+		},
+		{
+			name: "nil public key",
+			msg: &PaymentPromise{
+				SignerPublicKey:   nil,
+				Namespace:         validNamespace,
+				BlobSize:          1000,
+				Commitment:        validCommitment,
+				RowVersion:        uint32(share.ShareVersionZero),
+				CreationTimestamp: time.Now(),
+				Signature:         []byte("valid-signature"),
+				Height:            100,
+				ChainId:           "celestia-test",
+			},
+			wantErr: true,
+			errType: sdkerrors.ErrInvalidPubKey,
+		},
+		{
+			name: "empty namespace",
+			msg: &PaymentPromise{
+				SignerPublicKey:   pubKeyAny,
+				Namespace:         []byte{},
+				BlobSize:          1000,
+				Commitment:        validCommitment,
+				RowVersion:        uint32(share.ShareVersionZero),
+				CreationTimestamp: time.Now(),
+				Signature:         []byte("valid-signature"),
+				Height:            100,
+				ChainId:           "celestia-test",
+			},
+			wantErr: true,
+			errType: sdkerrors.ErrInvalidRequest,
+		},
+		{
+			name: "invalid namespace size",
+			msg: &PaymentPromise{
+				SignerPublicKey:   pubKeyAny,
+				Namespace:         []byte{1, 2, 3}, // wrong size
+				BlobSize:          1000,
+				Commitment:        validCommitment,
+				RowVersion:        uint32(share.ShareVersionZero),
+				CreationTimestamp: time.Now(),
+				Signature:         []byte("valid-signature"),
+				Height:            100,
+				ChainId:           "celestia-test",
+			},
+			wantErr: true,
+			errType: sdkerrors.ErrInvalidRequest,
+		},
+		{
+			name: "zero blob size",
+			msg: &PaymentPromise{
+				SignerPublicKey:   pubKeyAny,
+				Namespace:         validNamespace,
+				BlobSize:          0,
+				Commitment:        validCommitment,
+				RowVersion:        uint32(share.ShareVersionZero),
+				CreationTimestamp: time.Now(),
+				Signature:         []byte("valid-signature"),
+				Height:            100,
+				ChainId:           "celestia-test",
+			},
+			wantErr: true,
+			errType: sdkerrors.ErrInvalidRequest,
+		},
+		{
+			name: "invalid commitment size",
+			msg: &PaymentPromise{
+				SignerPublicKey:   pubKeyAny,
+				Namespace:         validNamespace,
+				BlobSize:          1000,
+				Commitment:        []byte{1, 2, 3}, // wrong size
+				RowVersion:        uint32(share.ShareVersionZero),
+				CreationTimestamp: time.Now(),
+				Signature:         []byte("valid-signature"),
+				Height:            100,
+				ChainId:           "celestia-test",
+			},
+			wantErr: true,
+			errType: sdkerrors.ErrInvalidRequest,
+		},
+		{
+			name: "unsupported row version",
+			msg: &PaymentPromise{
+				SignerPublicKey:   pubKeyAny,
+				Namespace:         validNamespace,
+				BlobSize:          1000,
+				Commitment:        validCommitment,
+				RowVersion:        999, // unsupported version
+				CreationTimestamp: time.Now(),
+				Signature:         []byte("valid-signature"),
+				Height:            100,
+				ChainId:           "celestia-test",
+			},
+			wantErr: true,
+			errType: sdkerrors.ErrInvalidRequest,
+		},
+		{
+			name: "zero height",
+			msg: &PaymentPromise{
+				SignerPublicKey:   pubKeyAny,
+				Namespace:         validNamespace,
+				BlobSize:          1000,
+				Commitment:        validCommitment,
+				RowVersion:        uint32(share.ShareVersionZero),
+				CreationTimestamp: time.Now(),
+				Signature:         []byte("valid-signature"),
+				Height:            0,
+				ChainId:           "celestia-test",
+			},
+			wantErr: true,
+			errType: sdkerrors.ErrInvalidRequest,
+		},
+		{
+			name: "empty signature",
+			msg: &PaymentPromise{
+				SignerPublicKey:   pubKeyAny,
+				Namespace:         validNamespace,
+				BlobSize:          1000,
+				Commitment:        validCommitment,
+				RowVersion:        uint32(share.ShareVersionZero),
+				CreationTimestamp: time.Now(),
+				Signature:         []byte{},
+				Height:            100,
+				ChainId:           "celestia-test",
+			},
+			wantErr: true,
+			errType: sdkerrors.ErrInvalidRequest,
+		},
+		{
+			name: "empty chain ID",
+			msg: &PaymentPromise{
+				SignerPublicKey:   pubKeyAny,
+				Namespace:         validNamespace,
+				BlobSize:          1000,
+				Commitment:        validCommitment,
+				RowVersion:        uint32(share.ShareVersionZero),
+				CreationTimestamp: time.Now(),
+				Signature:         []byte("valid-signature"),
+				Height:            100,
+				ChainId:           "",
+			},
+			wantErr: true,
+			errType: sdkerrors.ErrInvalidRequest,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.msg.ValidateBasic()
+			if tt.wantErr {
+				require.Error(t, err)
+				if tt.errType != nil {
+					assert.Contains(t, err.Error(), tt.errType.Error())
+				}
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestMsgPayForFibre_ValidateBasic(t *testing.T) {
+	validAddr := "cosmos1qypqxpq9qcrsszg2pvxq6rs0zqg3yyc5lzv7xu"
+
+	// Create a valid PaymentPromise
+	privKey := secp256k1.GenPrivKey()
+	pubKey := privKey.PubKey()
+	pubKeyAny, err := types.NewAnyWithValue(pubKey)
+	require.NoError(t, err)
+
+	validNamespace := make([]byte, share.NamespaceSize)
+	validNamespace[0] = 0 // version 0
+	// Set bytes 19-28 to create a valid user namespace
+	for i := 19; i < share.NamespaceSize; i++ {
+		validNamespace[i] = 1
+	}
+
+	validCommitment := make([]byte, 32)
+	for i := range validCommitment {
+		validCommitment[i] = byte(i)
+	}
+
+	validPromise := &PaymentPromise{
+		SignerPublicKey:   pubKeyAny,
+		Namespace:         validNamespace,
+		BlobSize:          1000,
+		Commitment:        validCommitment,
+		RowVersion:        uint32(share.ShareVersionZero),
+		CreationTimestamp: time.Now(),
+		Signature:         []byte("valid-signature"),
+		Height:            100,
+		ChainId:           "celestia-test",
+	}
+
+	tests := []struct {
+		name    string
+		msg     *MsgPayForFibre
+		wantErr bool
+		errType error
+	}{
+		{
+			name: "valid message",
+			msg: &MsgPayForFibre{
+				Signer:              validAddr,
+				PaymentPromise:      *validPromise,
+				ValidatorSignatures: [][]byte{[]byte("sig1"), []byte("sig2")},
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid signer address",
+			msg: &MsgPayForFibre{
+				Signer:              "invalid-address",
+				PaymentPromise:      *validPromise,
+				ValidatorSignatures: [][]byte{[]byte("sig1")},
+			},
+			wantErr: true,
+			errType: sdkerrors.ErrInvalidAddress,
+		},
+		{
+			name: "no validator signatures",
+			msg: &MsgPayForFibre{
+				Signer:              validAddr,
+				PaymentPromise:      *validPromise,
+				ValidatorSignatures: [][]byte{},
+			},
+			wantErr: true,
+			errType: sdkerrors.ErrInvalidRequest,
+		},
+		{
+			name: "empty validator signature",
+			msg: &MsgPayForFibre{
+				Signer:              validAddr,
+				PaymentPromise:      *validPromise,
+				ValidatorSignatures: [][]byte{[]byte("sig1"), []byte{}},
+			},
+			wantErr: true,
+			errType: sdkerrors.ErrInvalidRequest,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.msg.ValidateBasic()
+			if tt.wantErr {
+				require.Error(t, err)
+				if tt.errType != nil {
+					assert.Contains(t, err.Error(), tt.errType.Error())
+				}
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestMsgPaymentPromiseTimeout_ValidateBasic(t *testing.T) {
+	validAddr := "cosmos1qypqxpq9qcrsszg2pvxq6rs0zqg3yyc5lzv7xu"
+
+	// Create a valid PaymentPromise
+	privKey := secp256k1.GenPrivKey()
+	pubKey := privKey.PubKey()
+	pubKeyAny, err := types.NewAnyWithValue(pubKey)
+	require.NoError(t, err)
+
+	validNamespace := make([]byte, share.NamespaceSize)
+	validNamespace[0] = 0 // version 0
+	// Set bytes 19-28 to create a valid user namespace
+	for i := 19; i < share.NamespaceSize; i++ {
+		validNamespace[i] = 1
+	}
+
+	validCommitment := make([]byte, 32)
+	for i := range validCommitment {
+		validCommitment[i] = byte(i)
+	}
+
+	validPromise := &PaymentPromise{
+		SignerPublicKey:   pubKeyAny,
+		Namespace:         validNamespace,
+		BlobSize:          1000,
+		Commitment:        validCommitment,
+		RowVersion:        uint32(share.ShareVersionZero),
+		CreationTimestamp: time.Now(),
+		Signature:         []byte("valid-signature"),
+		Height:            100,
+		ChainId:           "celestia-test",
+	}
+
+	tests := []struct {
+		name    string
+		msg     *MsgPaymentPromiseTimeout
+		wantErr bool
+		errType error
+	}{
+		{
+			name: "valid message",
+			msg: &MsgPaymentPromiseTimeout{
+				Signer:         validAddr,
+				PaymentPromise: *validPromise,
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid signer address",
+			msg: &MsgPaymentPromiseTimeout{
+				Signer:         "invalid-address",
+				PaymentPromise: *validPromise,
+			},
+			wantErr: true,
+			errType: sdkerrors.ErrInvalidAddress,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.msg.ValidateBasic()
+			if tt.wantErr {
+				require.Error(t, err)
+				if tt.errType != nil {
+					assert.Contains(t, err.Error(), tt.errType.Error())
+				}
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestMsgUpdateFibreParams_ValidateBasic(t *testing.T) {
+	validAddr := "cosmos1qypqxpq9qcrsszg2pvxq6rs0zqg3yyc5lzv7xu"
+	validParams := DefaultParams()
+
+	tests := []struct {
+		name    string
+		msg     *MsgUpdateFibreParams
+		wantErr bool
+		errType error
+	}{
+		{
+			name: "valid message",
+			msg: &MsgUpdateFibreParams{
+				Authority: validAddr,
+				Params:    validParams,
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid authority address",
+			msg: &MsgUpdateFibreParams{
+				Authority: "invalid-address",
+				Params:    validParams,
+			},
+			wantErr: true,
+			errType: sdkerrors.ErrInvalidAddress,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.msg.ValidateBasic()
+			if tt.wantErr {
+				require.Error(t, err)
+				if tt.errType != nil {
+					assert.Contains(t, err.Error(), tt.errType.Error())
+				}
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/x/fibre/types/msgs_test.go
+++ b/x/fibre/types/msgs_test.go
@@ -221,6 +221,21 @@ func TestPaymentPromiseValidateBasic(t *testing.T) {
 			wantErr: sdkerrors.ErrInvalidRequest,
 		},
 		{
+			name: "not a valid blob namespace",
+			msg: PaymentPromise{
+				SignerPublicKey:   signerPublicKey,
+				Namespace:         share.TxNamespace.Bytes(),
+				BlobSize:          blobSize,
+				Commitment:        commitment,
+				RowVersion:        rowVersion,
+				CreationTimestamp: creationTimestamp,
+				Signature:         signature,
+				Height:            height,
+				ChainId:           chainId,
+			},
+			wantErr: sdkerrors.ErrInvalidRequest,
+		},
+		{
 			name: "zero blob size",
 			msg: PaymentPromise{
 				SignerPublicKey:   signerPublicKey,

--- a/x/fibre/types/msgs_test.go
+++ b/x/fibre/types/msgs_test.go
@@ -21,14 +21,15 @@ func TestMsgDepositToEscrowValidateBasic(t *testing.T) {
 	// negativeCoin does not use sdk.NewCoin because sdk.NewCoin panics if the amount is negative.
 	negativeCoin := sdk.Coin{Denom: "utia", Amount: math.NewInt(-100)}
 
-	tests := []struct {
+	type testCase struct {
 		name    string
-		msg     *MsgDepositToEscrow
+		msg     MsgDepositToEscrow
 		wantErr error
-	}{
+	}
+	testCases := []testCase{
 		{
 			name: "valid message",
-			msg: &MsgDepositToEscrow{
+			msg: MsgDepositToEscrow{
 				Signer: signer,
 				Amount: oneCoin,
 			},
@@ -36,7 +37,7 @@ func TestMsgDepositToEscrowValidateBasic(t *testing.T) {
 		},
 		{
 			name: "invalid signer address",
-			msg: &MsgDepositToEscrow{
+			msg: MsgDepositToEscrow{
 				Signer: "invalid-address",
 				Amount: oneCoin,
 			},
@@ -44,7 +45,7 @@ func TestMsgDepositToEscrowValidateBasic(t *testing.T) {
 		},
 		{
 			name: "empty signer address",
-			msg: &MsgDepositToEscrow{
+			msg: MsgDepositToEscrow{
 				Signer: "",
 				Amount: oneCoin,
 			},
@@ -52,7 +53,7 @@ func TestMsgDepositToEscrowValidateBasic(t *testing.T) {
 		},
 		{
 			name: "zero amount",
-			msg: &MsgDepositToEscrow{
+			msg: MsgDepositToEscrow{
 				Signer: signer,
 				Amount: zeroCoin,
 			},
@@ -60,7 +61,7 @@ func TestMsgDepositToEscrowValidateBasic(t *testing.T) {
 		},
 		{
 			name: "negative coin",
-			msg: &MsgDepositToEscrow{
+			msg: MsgDepositToEscrow{
 				Signer: signer,
 				Amount: negativeCoin,
 			},
@@ -68,7 +69,7 @@ func TestMsgDepositToEscrowValidateBasic(t *testing.T) {
 		},
 	}
 
-	for _, tc := range tests {
+	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			err := tc.msg.ValidateBasic()
 			if tc.wantErr != nil {
@@ -81,53 +82,59 @@ func TestMsgDepositToEscrowValidateBasic(t *testing.T) {
 	}
 }
 
-func TestMsgRequestWithdrawal_ValidateBasic(t *testing.T) {
-	validAddr := "cosmos1qypqxpq9qcrsszg2pvxq6rs0zqg3yyc5lzv7xu"
-	validCoin := sdk.NewCoin("utia", math.NewInt(1000))
+func TestMsgRequestWithdrawalValidateBasic(t *testing.T) {
+	signer := "cosmos1qypqxpq9qcrsszg2pvxq6rs0zqg3yyc5lzv7xu"
+	oneCoin := sdk.NewCoin("utia", math.NewInt(1))
 	zeroCoin := sdk.NewCoin("utia", math.NewInt(0))
+	// negativeCoin does not use sdk.NewCoin because sdk.NewCoin panics if the amount is negative.
+	negativeCoin := sdk.Coin{Denom: "utia", Amount: math.NewInt(-100)}
 
-	tests := []struct {
+	type testCase struct {
 		name    string
-		msg     *MsgRequestWithdrawal
-		wantErr bool
-		errType error
-	}{
+		msg     MsgRequestWithdrawal
+		wantErr error
+	}
+	testCases := []testCase{
 		{
 			name: "valid message",
-			msg: &MsgRequestWithdrawal{
-				Signer: validAddr,
-				Amount: validCoin,
+			msg: MsgRequestWithdrawal{
+				Signer: signer,
+				Amount: oneCoin,
 			},
-			wantErr: false,
+			wantErr: nil,
 		},
 		{
 			name: "invalid signer address",
-			msg: &MsgRequestWithdrawal{
+			msg: MsgRequestWithdrawal{
 				Signer: "invalid-address",
-				Amount: validCoin,
+				Amount: oneCoin,
 			},
-			wantErr: true,
-			errType: sdkerrors.ErrInvalidAddress,
+			wantErr: sdkerrors.ErrInvalidAddress,
 		},
 		{
 			name: "zero amount",
-			msg: &MsgRequestWithdrawal{
-				Signer: validAddr,
+			msg: MsgRequestWithdrawal{
+				Signer: signer,
 				Amount: zeroCoin,
 			},
-			wantErr: true,
-			errType: sdkerrors.ErrInvalidCoins,
+			wantErr: sdkerrors.ErrInvalidCoins,
+		},
+		{
+			name: "negative amount",
+			msg: MsgRequestWithdrawal{
+				Signer: signer,
+				Amount: negativeCoin,
+			},
+			wantErr: sdkerrors.ErrInvalidCoins,
 		},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			err := tt.msg.ValidateBasic()
-			if tt.wantErr {
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.msg.ValidateBasic()
+			if tc.wantErr != nil {
 				require.Error(t, err)
-				if tt.errType != nil {
-					assert.Contains(t, err.Error(), tt.errType.Error())
-				}
+				require.ErrorIs(t, err, tc.wantErr)
 			} else {
 				require.NoError(t, err)
 			}

--- a/x/fibre/types/msgs_test.go
+++ b/x/fibre/types/msgs_test.go
@@ -147,7 +147,7 @@ func TestPaymentPromiseValidateBasic(t *testing.T) {
 	signerPublicKey := generatePubKeyAny(t)
 	namespace := generateNamespace(t)
 	blobSize := uint32(1000)
-	commitment := generateCommitment(t)
+	commitment := generateCommitment()
 	rowVersion := RowVersionZero
 	creationTimestamp := time.Now()
 	signature := []byte("valid-signature")
@@ -509,7 +509,7 @@ func generateNamespace(t *testing.T) []byte {
 	return namespace.Bytes()
 }
 
-func generateCommitment(t *testing.T) []byte {
+func generateCommitment() []byte {
 	commitment := make([]byte, 32)
 	for i := range commitment {
 		commitment[i] = byte(i)
@@ -530,7 +530,7 @@ func generatePaymentPromise(t *testing.T) PaymentPromise {
 		SignerPublicKey:   generatePubKeyAny(t),
 		Namespace:         generateNamespace(t),
 		BlobSize:          1000,
-		Commitment:        generateCommitment(t),
+		Commitment:        generateCommitment(),
 		RowVersion:        uint32(share.ShareVersionZero),
 		CreationTimestamp: time.Now(),
 		Signature:         []byte("valid-signature"),

--- a/x/fibre/types/params.go
+++ b/x/fibre/types/params.go
@@ -61,13 +61,13 @@ func (p Params) Validate() error {
 	if err := validateGasPerBlobByte(p.GasPerBlobByte); err != nil {
 		return err
 	}
-	if err := validateWithdrawalDelay(p.WithdrawalDelay); err != nil {
+	if err := validateWithdrawalDelay(&p.WithdrawalDelay); err != nil {
 		return err
 	}
-	if err := validatePaymentPromiseTimeout(p.PaymentPromiseTimeout); err != nil {
+	if err := validatePaymentPromiseTimeout(&p.PaymentPromiseTimeout); err != nil {
 		return err
 	}
-	if err := validatePaymentPromiseRetentionWindow(p.PaymentPromiseRetentionWindow); err != nil {
+	if err := validatePaymentPromiseRetentionWindow(&p.PaymentPromiseRetentionWindow); err != nil {
 		return err
 	}
 	return nil


### PR DESCRIPTION
Part of https://github.com/celestiaorg/celestia-app-fibre/issues/1

To-do:
- [x] Verify that this actually implements all the stateless validation described in the spec
- [x] ~~Verify the "stateless signature" checks. Validator signatures must use ed25519 and we want to use the Go std lib implementation for that~~ the spec still has signature verification as a stateful thing so this isn't needed yet.