### PR TITLE
feat(x/fibre): add validator `Set` and `SetGetter` types

### DIFF
--- a/x/fibre/validator/set.go
+++ b/x/fibre/validator/set.go
@@ -1,0 +1,11 @@
+package validator
+
+import (
+	core "github.com/cometbft/cometbft/types"
+)
+
+// Set wraps [*core.ValidatorSet] with the height at which it is valid.
+type Set struct {
+	*core.ValidatorSet
+	Height uint64
+}

--- a/x/fibre/validator/set_getter.go
+++ b/x/fibre/validator/set_getter.go
@@ -1,0 +1,15 @@
+package validator
+
+import (
+	"context"
+)
+
+// SetGetter defines an interface for retrieving [Set].
+type SetGetter interface {
+	// Head returns the latest [Set].
+	Head(context.Context) (Set, error)
+
+	// GetByHeight returns the [Set] at the given height.
+	// Height must be greater than 0.
+	GetByHeight(context.Context, uint64) (Set, error)
+}


### PR DESCRIPTION
Adds `Set` and `SetGetter` interface for retrieving validator sets.

* The newly introduced `validator` pkg follows the domain-driven design common in Go practices, as opposed to placing everything in the types pkg or file. More things are to be added to this package. The pkg can be renamed to server or to any other better name that describes this domain.
* The `Set` conveniently reuses `core.ValidatorSet`, methods of which were audited multiple times and are helpful for fibre needs as you will see in future PRs. 
* `SetGetter` may sound like an oxymoron, considering how many meanings the word set has. We can rename it something like `validator.Snapshot` if we care about this.
* There are 3 `SetGetter` implementations:
  - Over LN's `HeaderService`.
  - Over core's `state.Store` for embedded mode.
  - Over core's GRPC `BlockAPIClient` for future detached mode. 
  - All the implementations will be added in later PRs once we come closer to core and LN integrations
