### PR TITLE
feat(x/fibre): add `SignatureSet` for validator signature collection

### DIFF
--- a/x/fibre/validator/signature_set.go
+++ b/x/fibre/validator/signature_set.go
@@ -9,13 +9,6 @@ import (
 	core "github.com/cometbft/cometbft/types"
 )
 
-var (
-	// ErrNotEnoughSignatures indicates that not enough signatures were collected to meet the count threshold.
-	ErrNotEnoughSignatures = fmt.Errorf("not enough signatures")
-	// ErrNotEnoughVotingPower indicates that the collected signatures don't have sufficient voting power.
-	ErrNotEnoughVotingPower = fmt.Errorf("not enough voting power")
-)
-
 // SignatureSet collects and validates signatures from validators.
 // It is safe for concurrent use.
 type SignatureSet struct {
@@ -78,18 +71,42 @@ func (ss *SignatureSet) Done() <-chan struct{} {
 }
 
 // Signatures returns all collected signatures if thresholds are met.
-// Returns [ErrNotEnoughSignatures] if count threshold is not met.
-// Returns [ErrNotEnoughVotingPower] if voting power threshold is not met.
+// Returns [NotEnoughSignaturesError] if either count or voting power threshold is not met.
+// The error contains the partially collected signatures and threshold information.
 func (ss *SignatureSet) Signatures() ([][]byte, error) {
 	ss.mu.Lock()
 	defer ss.mu.Unlock()
 
-	if len(ss.signatures) < ss.minRequiredSignatures {
-		return nil, ErrNotEnoughSignatures
-	}
-	if ss.votingPower < ss.minRequiredVotingPower {
-		return nil, ErrNotEnoughVotingPower
+	countNotMet := len(ss.signatures) < ss.minRequiredSignatures
+	powerNotMet := ss.votingPower < ss.minRequiredVotingPower
+	if countNotMet || powerNotMet {
+		return nil, &NotEnoughSignaturesError{
+			Collected:      ss.signatures,
+			RequiredCount:  ss.minRequiredSignatures,
+			CollectedPower: ss.votingPower,
+			RequiredPower:  ss.minRequiredVotingPower,
+		}
 	}
 
 	return ss.signatures, nil
+}
+
+// NotEnoughSignaturesError indicates that signature collection did not meet the required thresholds.
+// It contains the partially collected signatures and threshold information.
+type NotEnoughSignaturesError struct {
+	Collected      [][]byte
+	RequiredCount  int
+	CollectedPower int64
+	RequiredPower  int64
+}
+
+func (e *NotEnoughSignaturesError) Error() string {
+	switch {
+	case len(e.Collected) < e.RequiredCount:
+		return fmt.Sprintf("not enough signatures: collected %d, required %d", len(e.Collected), e.RequiredCount)
+	case e.CollectedPower < e.RequiredPower:
+		return fmt.Sprintf("not enough voting power: collected %d, required %d", e.CollectedPower, e.RequiredPower)
+	default:
+		panic("unreachable")
+	}
 }

--- a/x/fibre/validator/signature_set.go
+++ b/x/fibre/validator/signature_set.go
@@ -1,7 +1,6 @@
 package validator
 
 import (
-	"context"
 	"crypto/ed25519"
 	"fmt"
 	"sync"
@@ -10,45 +9,45 @@ import (
 	core "github.com/cometbft/cometbft/types"
 )
 
-// ErrNotEnoughSignatures indicates that not enough signatures with total sufficient voting power were accumulated.
-var ErrNotEnoughSignatures = fmt.Errorf("not enough signatures with voting power")
+var (
+	// ErrNotEnoughSignatures indicates that not enough signatures were collected to meet the count threshold.
+	ErrNotEnoughSignatures = fmt.Errorf("not enough signatures")
+	// ErrNotEnoughVotingPower indicates that the collected signatures don't have sufficient voting power.
+	ErrNotEnoughVotingPower = fmt.Errorf("not enough voting power")
+)
 
-// SignatureSet collects and validates signatures from validators until thresholds are met.
+// SignatureSet collects and validates signatures from validators.
 // It is safe for concurrent use.
 type SignatureSet struct {
-	totalCount          int
-	requiredBytesSigned []byte
-	requiredVotingPower int64
-	requiredCount       int
+	mu sync.Mutex
 
-	mu             sync.Mutex
-	votingPower    int64
-	validatorCount int
-	signatures     [][]byte
-	done           chan struct{}
+	requiredBytesSigned    []byte
+	minRequiredVotingPower int64
+	minRequiredSignatures  int
+
+	votingPower int64
+	signatures  [][]byte
+	done        chan struct{}
 }
 
 // NewSignatureSet creates a new [SignatureSet] for collecting and validating signatures.
 func (s Set) NewSignatureSet(targetVotingPower, targetValidatorsCount cmtmath.Fraction, requiredBytesSigned []byte) *SignatureSet {
-	// follows arithmetic logic from cometbft for calculating required voting power
-	requiredVotingPower := s.TotalVotingPower() * int64(targetVotingPower.Numerator) / int64(targetVotingPower.Denominator)
-	requiredCount := s.Size() * int(targetValidatorsCount.Numerator) / int(targetValidatorsCount.Denominator)
+	minRequiredVotingPower := s.TotalVotingPower() * int64(targetVotingPower.Numerator) / int64(targetVotingPower.Denominator)
+	minRequiredSignatures := s.Size() * int(targetValidatorsCount.Numerator) / int(targetValidatorsCount.Denominator)
 
 	return &SignatureSet{
-		totalCount:          s.Size(),
-		requiredBytesSigned: requiredBytesSigned,
-		requiredVotingPower: requiredVotingPower,
-		requiredCount:       requiredCount,
-		signatures:          make([][]byte, 0, s.Size()),
-		done:                make(chan struct{}),
+		requiredBytesSigned:    requiredBytesSigned,
+		minRequiredVotingPower: minRequiredVotingPower,
+		minRequiredSignatures:  minRequiredSignatures,
+		signatures:             make([][]byte, 0, s.Size()),
+		done:                   make(chan struct{}),
 	}
 }
 
 // Add validates and adds a signature from the given validator.
-// Returns an error if the signature is invalid or the validator was already added.
-// When both voting power and count thresholds are met, the done channel is closed.
+// Returns an error if the signature is invalid.
 func (ss *SignatureSet) Add(val *core.Validator, signature []byte) error {
-	// verify signature if not missing
+	// verify signature
 	pubKey := val.PubKey.Bytes()
 	if !ed25519.Verify(ed25519.PublicKey(pubKey), ss.requiredBytesSigned, signature) {
 		return fmt.Errorf("invalid signature from validator %s", val.Address.String())
@@ -58,60 +57,40 @@ func (ss *SignatureSet) Add(val *core.Validator, signature []byte) error {
 	defer ss.mu.Unlock()
 
 	// add to collection
-	ss.validatorCount++
 	ss.votingPower += val.VotingPower
 	ss.signatures = append(ss.signatures, signature)
 
-	// check if thresholds are met and close done channel if not already closed
-	if ss.votingPower < ss.requiredVotingPower || ss.validatorCount < ss.requiredCount {
-		return nil
+	// check if thresholds are met and close done channel
+	if len(ss.signatures) >= ss.minRequiredSignatures && ss.votingPower >= ss.minRequiredVotingPower {
+		select {
+		case <-ss.done:
+			// already closed
+		default:
+			close(ss.done)
+		}
 	}
 
-	select {
-	case <-ss.done:
-	default:
-		close(ss.done)
-	}
 	return nil
 }
 
-// Miss marks the validator as not responding without adding a signature.
-func (ss *SignatureSet) Miss() {
+// Done returns a channel that is closed when enough signatures are collected to meet both thresholds.
+func (ss *SignatureSet) Done() <-chan struct{} {
+	return ss.done
+}
+
+// Signatures returns all collected signatures if thresholds are met.
+// Returns [ErrNotEnoughSignatures] if count threshold is not met.
+// Returns [ErrNotEnoughVotingPower] if voting power threshold is not met.
+func (ss *SignatureSet) Signatures() ([][]byte, error) {
 	ss.mu.Lock()
 	defer ss.mu.Unlock()
 
-	ss.validatorCount++
-	if ss.validatorCount < ss.totalCount {
-		return
+	if len(ss.signatures) < ss.minRequiredSignatures {
+		return nil, ErrNotEnoughSignatures
+	}
+	if ss.votingPower < ss.minRequiredVotingPower {
+		return nil, ErrNotEnoughVotingPower
 	}
 
-	select {
-	case <-ss.done:
-	default:
-		close(ss.done)
-	}
-}
-
-// Await waits for the signature collection thresholds to be met or for the context to be cancelled.
-// Returns nil if thresholds are met or error if not enough signatures with voting power accumulated or
-// context errors.
-func (ss *SignatureSet) Await(ctx context.Context) error {
-	select {
-	case <-ss.done:
-		ss.mu.Lock()
-		defer ss.mu.Unlock()
-		if ss.votingPower < ss.requiredVotingPower {
-			return ErrNotEnoughSignatures
-		}
-		return nil
-	case <-ctx.Done():
-		return ctx.Err()
-	}
-}
-
-// Signatures returns all collected signatures.
-func (ss *SignatureSet) Signatures() [][]byte {
-	ss.mu.Lock()
-	defer ss.mu.Unlock()
-	return ss.signatures
+	return ss.signatures, nil
 }

--- a/x/fibre/validator/signature_set.go
+++ b/x/fibre/validator/signature_set.go
@@ -1,0 +1,117 @@
+package validator
+
+import (
+	"context"
+	"crypto/ed25519"
+	"fmt"
+	"sync"
+
+	cmtmath "github.com/cometbft/cometbft/libs/math"
+	core "github.com/cometbft/cometbft/types"
+)
+
+// ErrNotEnoughSignatures indicates that not enough signatures with total sufficient voting power were accumulated.
+var ErrNotEnoughSignatures = fmt.Errorf("not enough signatures with voting power")
+
+// SignatureSet collects and validates signatures from validators until thresholds are met.
+// It is safe for concurrent use.
+type SignatureSet struct {
+	totalCount          int
+	requiredBytesSigned []byte
+	requiredVotingPower int64
+	requiredCount       int
+
+	mu             sync.Mutex
+	votingPower    int64
+	validatorCount int
+	signatures     [][]byte
+	done           chan struct{}
+}
+
+// NewSignatureSet creates a new [SignatureSet] for collecting and validating signatures.
+func (s Set) NewSignatureSet(targetVotingPower, targetValidatorsCount cmtmath.Fraction, requiredBytesSigned []byte) *SignatureSet {
+	// follows arithmetic logic from cometbft for calculating required voting power
+	requiredVotingPower := s.TotalVotingPower() * int64(targetVotingPower.Numerator) / int64(targetVotingPower.Denominator)
+	requiredCount := s.Size() * int(targetValidatorsCount.Numerator) / int(targetValidatorsCount.Denominator)
+
+	return &SignatureSet{
+		totalCount:          s.Size(),
+		requiredBytesSigned: requiredBytesSigned,
+		requiredVotingPower: requiredVotingPower,
+		requiredCount:       requiredCount,
+		signatures:          make([][]byte, 0, s.Size()),
+		done:                make(chan struct{}),
+	}
+}
+
+// Add validates and adds a signature from the given validator.
+// Returns an error if the signature is invalid or the validator was already added.
+// When both voting power and count thresholds are met, the done channel is closed.
+func (ss *SignatureSet) Add(val *core.Validator, signature []byte) error {
+	// verify signature if not missing
+	pubKey := val.PubKey.Bytes()
+	if !ed25519.Verify(ed25519.PublicKey(pubKey), ss.requiredBytesSigned, signature) {
+		return fmt.Errorf("invalid signature from validator %s", val.Address.String())
+	}
+
+	ss.mu.Lock()
+	defer ss.mu.Unlock()
+
+	// add to collection
+	ss.validatorCount++
+	ss.votingPower += val.VotingPower
+	ss.signatures = append(ss.signatures, signature)
+
+	// check if thresholds are met and close done channel if not already closed
+	if ss.votingPower < ss.requiredVotingPower || ss.validatorCount < ss.requiredCount {
+		return nil
+	}
+
+	select {
+	case <-ss.done:
+	default:
+		close(ss.done)
+	}
+	return nil
+}
+
+// Miss marks the validator as not responding without adding a signature.
+func (ss *SignatureSet) Miss() {
+	ss.mu.Lock()
+	defer ss.mu.Unlock()
+
+	ss.validatorCount++
+	if ss.validatorCount < ss.totalCount {
+		return
+	}
+
+	select {
+	case <-ss.done:
+	default:
+		close(ss.done)
+	}
+}
+
+// Await waits for the signature collection thresholds to be met or for the context to be cancelled.
+// Returns nil if thresholds are met or error if not enough signatures with voting power accumulated or
+// context errors.
+func (ss *SignatureSet) Await(ctx context.Context) error {
+	select {
+	case <-ss.done:
+		ss.mu.Lock()
+		defer ss.mu.Unlock()
+		if ss.votingPower < ss.requiredVotingPower {
+			return ErrNotEnoughSignatures
+		}
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// Signatures returns all collected signatures.
+func (ss *SignatureSet) Signatures() [][]byte {
+	ss.mu.Lock()
+	defer ss.mu.Unlock()
+	return ss.signatures
+}

--- a/x/fibre/validator/signature_set.go
+++ b/x/fibre/validator/signature_set.go
@@ -19,12 +19,11 @@ var (
 // SignatureSet collects and validates signatures from validators.
 // It is safe for concurrent use.
 type SignatureSet struct {
-	mu sync.Mutex
-
 	requiredBytesSigned    []byte
 	minRequiredVotingPower int64
 	minRequiredSignatures  int
 
+	mu          sync.Mutex
 	votingPower int64
 	signatures  [][]byte
 	done        chan struct{}

--- a/x/fibre/validator/signature_set_test.go
+++ b/x/fibre/validator/signature_set_test.go
@@ -1,0 +1,150 @@
+package validator_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/celestiaorg/celestia-app/v6/x/fibre/validator"
+	"github.com/cometbft/cometbft/crypto/ed25519"
+	cmtmath "github.com/cometbft/cometbft/libs/math"
+	core "github.com/cometbft/cometbft/types"
+	"github.com/stretchr/testify/require"
+)
+
+// makeValidators creates n validators with the given voting power each
+func makeValidators(n int, votingPower int64) ([]*core.Validator, []ed25519.PrivKey) {
+	validators := make([]*core.Validator, n)
+	privKeys := make([]ed25519.PrivKey, n)
+	for i := 0; i < n; i++ {
+		privKeys[i] = ed25519.GenPrivKey()
+		validators[i] = core.NewValidator(privKeys[i].PubKey(), votingPower)
+	}
+	return validators, privKeys
+}
+
+type testSetup struct {
+	validators []*core.Validator
+	privKeys   []ed25519.PrivKey
+	valSet     validator.Set
+	sigSet     *validator.SignatureSet
+	signBytes  []byte
+}
+
+func setupSignatureSet(numVals int, votingPower int64, votingPowerFrac, countFrac cmtmath.Fraction) *testSetup {
+	signBytes := []byte("test message to sign")
+	validators, privKeys := makeValidators(numVals, votingPower)
+	valSet := validator.Set{
+		ValidatorSet: core.NewValidatorSet(validators),
+		Height:       100,
+	}
+	sigSet := valSet.NewSignatureSet(votingPowerFrac, countFrac, signBytes)
+
+	return &testSetup{
+		validators: validators,
+		privKeys:   privKeys,
+		valSet:     valSet,
+		sigSet:     sigSet,
+		signBytes:  signBytes,
+	}
+}
+
+func TestSignatureSet(t *testing.T) {
+	twoThirds := cmtmath.Fraction{Numerator: 2, Denominator: 3}
+	half := cmtmath.Fraction{Numerator: 1, Denominator: 2}
+
+	t.Run("NotEnoughVotingPower", func(t *testing.T) {
+		s := setupSignatureSet(5, 10, twoThirds, twoThirds)
+
+		// Add 2 signatures (20 voting power, not meeting threshold of 34)
+		for i := range 2 {
+			signature, err := s.privKeys[i].Sign(s.signBytes)
+			require.NoError(t, err)
+			require.NoError(t, s.sigSet.Add(s.validators[i], signature))
+		}
+
+		// Mark remaining validators as missing
+		for i := 2; i < 5; i++ {
+			s.sigSet.Miss()
+		}
+
+		err := s.sigSet.Await(context.Background())
+		require.ErrorIs(t, err, validator.ErrNotEnoughSignatures)
+		require.Len(t, s.sigSet.Signatures(), 2)
+	})
+
+	t.Run("SuccessSequential", func(t *testing.T) {
+		s := setupSignatureSet(5, 10, twoThirds, twoThirds)
+
+		// Add 4 signatures (40 voting power, meets threshold of 34)
+		for i := range 4 {
+			signature, err := s.privKeys[i].Sign(s.signBytes)
+			require.NoError(t, err)
+			require.NoError(t, s.sigSet.Add(s.validators[i], signature))
+		}
+
+		require.NoError(t, s.sigSet.Await(context.Background()))
+		require.Len(t, s.sigSet.Signatures(), 4)
+	})
+
+	t.Run("SuccessConcurrent", func(t *testing.T) {
+		s := setupSignatureSet(10, 10, twoThirds, twoThirds)
+
+		var wg sync.WaitGroup
+		for i := range 10 {
+			wg.Add(1)
+			go func(idx int) {
+				defer wg.Done()
+				signature, err := s.privKeys[idx].Sign(s.signBytes)
+				require.NoError(t, err)
+				require.NoError(t, s.sigSet.Add(s.validators[idx], signature))
+			}(i)
+		}
+		wg.Wait()
+
+		require.NoError(t, s.sigSet.Await(context.Background()))
+		require.Len(t, s.sigSet.Signatures(), 10)
+	})
+
+	t.Run("InvalidSignature", func(t *testing.T) {
+		s := setupSignatureSet(3, 10, half, half)
+
+		wrongSignBytes := []byte("wrong message")
+		signature, err := s.privKeys[0].Sign(wrongSignBytes)
+		require.NoError(t, err)
+
+		err = s.sigSet.Add(s.validators[0], signature)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "invalid signature")
+	})
+
+	t.Run("ContextCancellation", func(t *testing.T) {
+		s := setupSignatureSet(3, 10, twoThirds, twoThirds)
+
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+		defer cancel()
+
+		err := s.sigSet.Await(ctx)
+		require.ErrorIs(t, err, context.DeadlineExceeded)
+	})
+
+	t.Run("MixedMissAndValid", func(t *testing.T) {
+		s := setupSignatureSet(5, 10, half, half)
+
+		// Add 3 valid signatures (30 voting power, meets threshold of 25)
+		for i := range 3 {
+			signature, err := s.privKeys[i].Sign(s.signBytes)
+			require.NoError(t, err)
+			require.NoError(t, s.sigSet.Add(s.validators[i], signature))
+		}
+
+		// Mark 2 as missing
+		for i := 3; i < 5; i++ {
+			s.sigSet.Miss()
+		}
+
+		require.NoError(t, s.sigSet.Await(context.Background()))
+		require.Len(t, s.sigSet.Signatures(), 3)
+	})
+}

--- a/x/fibre/validator/signature_set_test.go
+++ b/x/fibre/validator/signature_set_test.go
@@ -15,7 +15,7 @@ import (
 func makeValidators(n int, votingPower int64) ([]*core.Validator, []ed25519.PrivKey) {
 	validators := make([]*core.Validator, n)
 	privKeys := make([]ed25519.PrivKey, n)
-	for i := 0; i < n; i++ {
+	for i := range n {
 		privKeys[i] = ed25519.GenPrivKey()
 		validators[i] = core.NewValidator(privKeys[i].PubKey(), votingPower)
 	}
@@ -59,37 +59,67 @@ func TestSignatureSet(t *testing.T) {
 		// 2/3 of 50 = 33 requiredVotingPower
 		// 2/3 of 5 = 3 requiredCount
 		// Add 3 signatures (30 voting power, meets count threshold of 3 but not voting power threshold of 33)
-		for i := 0; i < 3; i++ {
+		for i := range 3 {
 			signature, err := s.privKeys[i].Sign(s.signBytes)
 			require.NoError(t, err)
 			require.NoError(t, s.sigSet.Add(s.validators[i], signature))
 		}
 
+		// Check that Done() is NOT closed when thresholds are not met
+		select {
+		case <-s.sigSet.Done():
+			t.Fatal("Done() should not be closed when thresholds are not met")
+		default:
+		}
+
 		sigs, err := s.sigSet.Signatures()
-		require.ErrorIs(t, err, validator.ErrNotEnoughVotingPower)
 		require.Nil(t, sigs)
+		require.Error(t, err)
+
+		var sigErr *validator.NotEnoughSignaturesError
+		require.ErrorAs(t, err, &sigErr)
+		require.Len(t, sigErr.Collected, 3)
+		require.Equal(t, int64(30), sigErr.CollectedPower)
+		require.Equal(t, int64(33), sigErr.RequiredPower)
+		require.Equal(t, 3, sigErr.RequiredCount)
+		require.Contains(t, err.Error(), "not enough voting power")
 	})
 
 	t.Run("NotEnoughSignatures", func(t *testing.T) {
 		s := setupSignatureSet(5, 10, twoThirds, twoThirds)
 
 		// Add only 2 signatures (requiredCount = 3)
-		for i := 0; i < 2; i++ {
+		for i := range 2 {
 			signature, err := s.privKeys[i].Sign(s.signBytes)
 			require.NoError(t, err)
 			require.NoError(t, s.sigSet.Add(s.validators[i], signature))
 		}
 
+		// Check that Done() is NOT closed when thresholds are not met
+		select {
+		case <-s.sigSet.Done():
+			t.Fatal("Done() should not be closed when thresholds are not met")
+		default:
+		}
+
 		sigs, err := s.sigSet.Signatures()
-		require.ErrorIs(t, err, validator.ErrNotEnoughSignatures)
 		require.Nil(t, sigs)
+		require.Error(t, err)
+
+		var sigErr *validator.NotEnoughSignaturesError
+		require.ErrorAs(t, err, &sigErr)
+		require.Len(t, sigErr.Collected, 2)
+		require.Equal(t, 3, sigErr.RequiredCount)
+		require.Equal(t, int64(20), sigErr.CollectedPower)
+		require.Equal(t, int64(33), sigErr.RequiredPower)
+		require.Contains(t, err.Error(), "not enough signatures")
 	})
 
 	t.Run("SuccessSequential", func(t *testing.T) {
 		s := setupSignatureSet(5, 10, twoThirds, twoThirds)
 
 		// Add 4 signatures (40 voting power, meets both thresholds)
-		for i := 0; i < 4; i++ {
+		for i := range 4 {
 			signature, err := s.privKeys[i].Sign(s.signBytes)
 			require.NoError(t, err)
 			require.NoError(t, s.sigSet.Add(s.validators[i], signature))
@@ -111,7 +141,7 @@ func TestSignatureSet(t *testing.T) {
 		s := setupSignatureSet(10, 10, twoThirds, twoThirds)
 
 		var wg sync.WaitGroup
-		for i := 0; i < 10; i++ {
+		for i := range 10 {
 			wg.Add(1)
 			go func(idx int) {
 				defer wg.Done()
@@ -150,7 +180,7 @@ func TestSignatureSet(t *testing.T) {
 		s := setupSignatureSet(5, 10, half, half)
 
 		// Add 3 valid signatures (30 voting power, meets threshold of 25)
-		for i := 0; i < 3; i++ {
+		for i := range 3 {
 			signature, err := s.privKeys[i].Sign(s.signBytes)
 			require.NoError(t, err)
 			require.NoError(t, s.sigSet.Add(s.validators[i], signature))

--- a/x/fibre/validator/signature_set_test.go
+++ b/x/fibre/validator/signature_set_test.go
@@ -1,10 +1,8 @@
 package validator_test
 
 import (
-	"context"
 	"sync"
 	"testing"
-	"time"
 
 	"github.com/celestiaorg/celestia-app/v6/x/fibre/validator"
 	"github.com/cometbft/cometbft/crypto/ed25519"
@@ -57,42 +55,63 @@ func TestSignatureSet(t *testing.T) {
 	t.Run("NotEnoughVotingPower", func(t *testing.T) {
 		s := setupSignatureSet(5, 10, twoThirds, twoThirds)
 
-		// Add 2 signatures (20 voting power, not meeting threshold of 34)
-		for i := range 2 {
+		// 5 validators * 10 voting power = 50 total
+		// 2/3 of 50 = 33 requiredVotingPower
+		// 2/3 of 5 = 3 requiredCount
+		// Add 3 signatures (30 voting power, meets count threshold of 3 but not voting power threshold of 33)
+		for i := 0; i < 3; i++ {
 			signature, err := s.privKeys[i].Sign(s.signBytes)
 			require.NoError(t, err)
 			require.NoError(t, s.sigSet.Add(s.validators[i], signature))
 		}
 
-		// Mark remaining validators as missing
-		for i := 2; i < 5; i++ {
-			s.sigSet.Miss()
+		sigs, err := s.sigSet.Signatures()
+		require.ErrorIs(t, err, validator.ErrNotEnoughVotingPower)
+		require.Nil(t, sigs)
+	})
+
+	t.Run("NotEnoughSignatures", func(t *testing.T) {
+		s := setupSignatureSet(5, 10, twoThirds, twoThirds)
+
+		// Add only 2 signatures (requiredCount = 3)
+		for i := 0; i < 2; i++ {
+			signature, err := s.privKeys[i].Sign(s.signBytes)
+			require.NoError(t, err)
+			require.NoError(t, s.sigSet.Add(s.validators[i], signature))
 		}
 
-		err := s.sigSet.Await(context.Background())
+		sigs, err := s.sigSet.Signatures()
 		require.ErrorIs(t, err, validator.ErrNotEnoughSignatures)
-		require.Len(t, s.sigSet.Signatures(), 2)
+		require.Nil(t, sigs)
 	})
 
 	t.Run("SuccessSequential", func(t *testing.T) {
 		s := setupSignatureSet(5, 10, twoThirds, twoThirds)
 
-		// Add 4 signatures (40 voting power, meets threshold of 34)
-		for i := range 4 {
+		// Add 4 signatures (40 voting power, meets both thresholds)
+		for i := 0; i < 4; i++ {
 			signature, err := s.privKeys[i].Sign(s.signBytes)
 			require.NoError(t, err)
 			require.NoError(t, s.sigSet.Add(s.validators[i], signature))
 		}
 
-		require.NoError(t, s.sigSet.Await(context.Background()))
-		require.Len(t, s.sigSet.Signatures(), 4)
+		// Check that Done() is closed
+		select {
+		case <-s.sigSet.Done():
+		default:
+			t.Fatal("Done() should be closed when thresholds are met")
+		}
+
+		sigs, err := s.sigSet.Signatures()
+		require.NoError(t, err)
+		require.Len(t, sigs, 4)
 	})
 
 	t.Run("SuccessConcurrent", func(t *testing.T) {
 		s := setupSignatureSet(10, 10, twoThirds, twoThirds)
 
 		var wg sync.WaitGroup
-		for i := range 10 {
+		for i := 0; i < 10; i++ {
 			wg.Add(1)
 			go func(idx int) {
 				defer wg.Done()
@@ -103,8 +122,16 @@ func TestSignatureSet(t *testing.T) {
 		}
 		wg.Wait()
 
-		require.NoError(t, s.sigSet.Await(context.Background()))
-		require.Len(t, s.sigSet.Signatures(), 10)
+		// Check that Done() is closed
+		select {
+		case <-s.sigSet.Done():
+		default:
+			t.Fatal("Done() should be closed when thresholds are met")
+		}
+
+		sigs, err := s.sigSet.Signatures()
+		require.NoError(t, err)
+		require.Len(t, sigs, 10)
 	})
 
 	t.Run("InvalidSignature", func(t *testing.T) {
@@ -119,32 +146,25 @@ func TestSignatureSet(t *testing.T) {
 		require.Contains(t, err.Error(), "invalid signature")
 	})
 
-	t.Run("ContextCancellation", func(t *testing.T) {
-		s := setupSignatureSet(3, 10, twoThirds, twoThirds)
-
-		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
-		defer cancel()
-
-		err := s.sigSet.Await(ctx)
-		require.ErrorIs(t, err, context.DeadlineExceeded)
-	})
-
 	t.Run("MixedMissAndValid", func(t *testing.T) {
 		s := setupSignatureSet(5, 10, half, half)
 
 		// Add 3 valid signatures (30 voting power, meets threshold of 25)
-		for i := range 3 {
+		for i := 0; i < 3; i++ {
 			signature, err := s.privKeys[i].Sign(s.signBytes)
 			require.NoError(t, err)
 			require.NoError(t, s.sigSet.Add(s.validators[i], signature))
 		}
 
-		// Mark 2 as missing
-		for i := 3; i < 5; i++ {
-			s.sigSet.Miss()
+		// Check that Done() is closed
+		select {
+		case <-s.sigSet.Done():
+		default:
+			t.Fatal("Done() should be closed when thresholds are met")
 		}
 
-		require.NoError(t, s.sigSet.Await(context.Background()))
-		require.Len(t, s.sigSet.Signatures(), 3)
+		sigs, err := s.sigSet.Signatures()
+		require.NoError(t, err)
+		require.Len(t, sigs, 3)
 	})
 }


### PR DESCRIPTION
Adds `SignatureSet` to allow fibre client to await the necessary signature
thresholds which are count and power from `validator.Set`.

Depends on https://github.com/celestiaorg/celestia-app-fibre/pull/5