### PR TITLE
feat(x/fibre): add `HostRegistry` interface 

### DIFF
--- a/x/fibre/validator/host.go
+++ b/x/fibre/validator/host.go
@@ -1,0 +1,23 @@
+package validator
+
+import (
+	"context"
+
+	core "github.com/cometbft/cometbft/types"
+)
+
+// Host represents a validator's network address as a string.
+// It can be a DNS name, IPv4 address, or IPv6 address, optionally with a port.
+type Host string
+
+// String returns the string representation of the host.
+func (h Host) String() string {
+	return string(h)
+}
+
+// HostRegistry provides a mapping from validators to their network hosts.
+type HostRegistry interface {
+	// GetHost returns the network host for a given validator.
+	// Returns an error if the validator's host cannot be determined.
+	GetHost(context.Context, *core.Validator) (Host, error)
+}


### PR DESCRIPTION
`HostRegistry` provides a mapping from validators to their network hosts, enabling the fibre client to resolve network addresses for validator connections.

The interface will be implemented once https://github.com/celestiaorg/fibre-da-spec/pull/4 is done. There might also be auxiliary testing implementations with a file-based registry or similar, rather than a state tree.

The interface currently returns just the host string. In an alternative design, it could return a GRPC client connection given the respective validator. However, the decision was not to rush coupling the transport layer and the state registry yet.