### PR TITLE
feat(x/fibre): Add `Assign` method to `validator.Set`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -59,8 +59,6 @@ require (
 	gopkg.in/yaml.v2 v2.4.0
 )
 
-require github.com/celestiaorg/reedsolomon v1.12.6-0.20250824224240-8b66bda83fd0 // indirect
-
 require (
 	cel.dev/expr v0.24.0 // indirect
 	cloud.google.com/go v0.120.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -59,6 +59,8 @@ require (
 	gopkg.in/yaml.v2 v2.4.0
 )
 
+require github.com/celestiaorg/reedsolomon v1.12.6-0.20250824224240-8b66bda83fd0 // indirect
+
 require (
 	cel.dev/expr v0.24.0 // indirect
 	cloud.google.com/go v0.120.0 // indirect

--- a/x/fibre/validator/set.go
+++ b/x/fibre/validator/set.go
@@ -1,6 +1,9 @@
 package validator
 
 import (
+	"math/big"
+
+	"github.com/celestiaorg/rsema1d"
 	core "github.com/cometbft/cometbft/types"
 )
 
@@ -8,4 +11,28 @@ import (
 type Set struct {
 	*core.ValidatorSet
 	Height uint64
+}
+
+// Assign returns a validator for the given commitment and row index using the formula:
+//
+//	validator_index = (commitment + row_index) mod num_validators
+//
+// The commitment is converted to a big.Int, added to the row index, and the result
+// is taken modulo the number of validators to determine the assignment.
+//
+// TODO(@Wondertan): This assignment algorithm is not final and may be changed
+// to improve distribution properties or security guarantees.
+func (s Set) Assign(commitment rsema1d.Commitment, rowIndex int) *core.Validator {
+	if len(s.Validators) == 0 {
+		return nil
+	}
+
+	// TODO(@Wondertan): If we ever end up using this assignment algorithm,
+	// we should move to uint256 libraries for up to 60% speedups per arithmetic operations
+	commitmentInt := new(big.Int).SetBytes(commitment[:])
+	rowIndexInt := big.NewInt(int64(rowIndex))
+	sum := new(big.Int).Add(commitmentInt, rowIndexInt)
+	valLenBig := big.NewInt(int64(len(s.Validators)))
+	idx := new(big.Int).Mod(sum, valLenBig)
+	return s.Validators[idx.Int64()]
 }

--- a/x/fibre/validator/set.go
+++ b/x/fibre/validator/set.go
@@ -13,7 +13,11 @@ type Set struct {
 	Height uint64
 }
 
-// Assign returns a validator for the given commitment and row index using the formula:
+// ShardMap maps validators to the row indices they are assigned.
+type ShardMap map[*core.Validator][]int
+
+// Assign returns a ShardMap containing all validators and their assigned row indices
+// for the given commitment and total number of rows. The assignment uses the formula:
 //
 //	validator_index = (commitment + row_index) mod num_validators
 //
@@ -22,17 +26,25 @@ type Set struct {
 //
 // TODO(@Wondertan): This assignment algorithm is not final and may be changed
 // to improve distribution properties or security guarantees.
-func (s Set) Assign(commitment rsema1d.Commitment, rowIndex int) *core.Validator {
-	if len(s.Validators) == 0 {
-		return nil
+func (s Set) Assign(commitment rsema1d.Commitment, totalRows int) ShardMap {
+	if len(s.Validators) == 0 || totalRows == 0 {
+		return make(ShardMap)
 	}
+
+	shardMap := make(ShardMap)
 
 	// TODO(@Wondertan): If we ever end up using this assignment algorithm,
 	// we should move to uint256 libraries for up to 60% speedups per arithmetic operations
 	commitmentInt := new(big.Int).SetBytes(commitment[:])
-	rowIndexInt := big.NewInt(int64(rowIndex))
-	sum := new(big.Int).Add(commitmentInt, rowIndexInt)
 	valLenBig := big.NewInt(int64(len(s.Validators)))
-	idx := new(big.Int).Mod(sum, valLenBig)
-	return s.Validators[idx.Int64()]
+
+	for rowIndex := range totalRows {
+		rowIndexInt := big.NewInt(int64(rowIndex))
+		sum := new(big.Int).Add(commitmentInt, rowIndexInt)
+		idx := new(big.Int).Mod(sum, valLenBig)
+		validator := s.Validators[idx.Int64()]
+		shardMap[validator] = append(shardMap[validator], rowIndex)
+	}
+
+	return shardMap
 }

--- a/x/fibre/validator/set_test.go
+++ b/x/fibre/validator/set_test.go
@@ -113,6 +113,12 @@ func TestSet_Assign(t *testing.T) {
 	})
 }
 
+// Results for 16,384 rows (K=4096, N=12288):
+//
+//	Validators    Time/op      Memory/op    Allocs/op
+//	10            ~1.47 ms     ~2.87 MB     ~47,649
+//	50            ~1.48 ms     ~2.90 MB     ~49,335
+//	100           ~1.50 ms     ~2.91 MB     ~49,901
 func BenchmarkSet_Assign(b *testing.B) {
 	commitment := rsema1d.Commitment{
 		1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16,

--- a/x/fibre/validator/set_test.go
+++ b/x/fibre/validator/set_test.go
@@ -20,17 +20,34 @@ func TestSet_Assign(t *testing.T) {
 	t.Run("EmptySet", func(t *testing.T) {
 		valSet := makeValidatorSet(0)
 
-		val := valSet.Assign(commitment, 0)
-		require.Nil(t, val)
+		shardMap := valSet.Assign(commitment, 10)
+		require.NotNil(t, shardMap)
+		require.Empty(t, shardMap)
+	})
+
+	t.Run("ZeroRows", func(t *testing.T) {
+		valSet := makeValidatorSet(3)
+
+		shardMap := valSet.Assign(commitment, 0)
+		require.NotNil(t, shardMap)
+		require.Empty(t, shardMap)
 	})
 
 	t.Run("SingleValidator", func(t *testing.T) {
 		valSet := makeValidatorSet(1)
 
-		for i := range 10 {
-			assignedVal := valSet.Assign(commitment, i)
-			require.NotNil(t, assignedVal)
-			require.Equal(t, valSet.Validators[0].Address.String(), assignedVal.Address.String())
+		numRows := 10
+		shardMap := valSet.Assign(commitment, numRows)
+		require.NotNil(t, shardMap)
+		require.Len(t, shardMap, 1)
+
+		// All rows should be assigned to the single validator
+		for _, rows := range shardMap {
+			require.Len(t, rows, numRows)
+			// Verify all row indices are present
+			for i := range numRows {
+				require.Contains(t, rows, i)
+			}
 		}
 	})
 
@@ -42,28 +59,40 @@ func TestSet_Assign(t *testing.T) {
 		var distCommitment rsema1d.Commitment
 		copy(distCommitment[:], hasher.Sum(nil))
 
-		counts := make(map[string]int)
 		totalRows := 16384
+		shardMap := valSet.Assign(distCommitment, totalRows)
 
-		for i := range totalRows {
-			val := valSet.Assign(distCommitment, i)
-			counts[val.Address.String()]++
-		}
+		require.Len(t, shardMap, len(valSet.Validators), "All validators should be assigned rows")
 
 		expectedPerValidator := totalRows / len(valSet.Validators)
-		require.Equal(t, len(valSet.Validators), len(counts))
+		totalAssigned := 0
 
 		lowest, highest := totalRows, 0
-		for _, count := range counts {
+		for val, rows := range shardMap {
+			count := len(rows)
+			totalAssigned += count
+
 			if count < lowest {
 				lowest = count
 			}
 			if count > highest {
 				highest = count
 			}
-			require.GreaterOrEqual(t, count, expectedPerValidator)
-			require.LessOrEqual(t, count, expectedPerValidator+1)
+
+			require.GreaterOrEqual(t, count, expectedPerValidator, "validator %s has too few rows", val.Address)
+			require.LessOrEqual(t, count, expectedPerValidator+1, "validator %s has too many rows", val.Address)
+
+			// Verify row indices are unique and in range
+			seen := make(map[int]bool)
+			for _, rowIdx := range rows {
+				require.False(t, seen[rowIdx], "duplicate row index %d", rowIdx)
+				require.GreaterOrEqual(t, rowIdx, 0)
+				require.Less(t, rowIdx, totalRows)
+				seen[rowIdx] = true
+			}
 		}
+
+		require.Equal(t, totalRows, totalAssigned, "All rows should be assigned")
 		t.Logf("Lowest assignments: %d, Highest assignments: %d", lowest, highest)
 	})
 
@@ -71,16 +100,45 @@ func TestSet_Assign(t *testing.T) {
 		valSet := makeValidatorSet(3)
 
 		numRows := 50
-		firstRun := make([]*core.Validator, numRows)
-		for i := range numRows {
-			firstRun[i] = valSet.Assign(commitment, i)
-		}
+		firstRun := valSet.Assign(commitment, numRows)
+		secondRun := valSet.Assign(commitment, numRows)
 
-		for i := range numRows {
-			val := valSet.Assign(commitment, i)
-			require.Equal(t, firstRun[i].Address.String(), val.Address.String())
+		require.Len(t, firstRun, len(secondRun))
+
+		for val, rows := range firstRun {
+			secondRows, ok := secondRun[val]
+			require.True(t, ok, "validator %s missing in second run", val.Address)
+			require.Equal(t, rows, secondRows, "row assignments differ for validator %s", val.Address)
 		}
 	})
+}
+
+func BenchmarkSet_Assign(b *testing.B) {
+	commitment := rsema1d.Commitment{
+		1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16,
+		17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32,
+	}
+
+	// Typical total rows for different blob sizes (K=4096, N=12288, total=16384)
+	totalRows := 16384
+
+	benchmarks := []struct {
+		name          string
+		numValidators int
+	}{
+		{"10_validators", 10},
+		{"50_validators", 50},
+		{"100_validators", 100},
+	}
+
+	for _, bm := range benchmarks {
+		b.Run(bm.name, func(b *testing.B) {
+			valSet := makeValidatorSet(bm.numValidators)
+			for b.Loop() {
+				_ = valSet.Assign(commitment, totalRows)
+			}
+		})
+	}
 }
 
 func makeValidatorSet(n int) validator.Set {

--- a/x/fibre/validator/set_test.go
+++ b/x/fibre/validator/set_test.go
@@ -1,0 +1,96 @@
+package validator_test
+
+import (
+	"crypto/sha256"
+	"testing"
+
+	"github.com/celestiaorg/celestia-app/v6/x/fibre/validator"
+	"github.com/celestiaorg/rsema1d"
+	"github.com/cometbft/cometbft/crypto/ed25519"
+	core "github.com/cometbft/cometbft/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSet_Assign(t *testing.T) {
+	commitment := rsema1d.Commitment{
+		1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16,
+		17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32,
+	}
+
+	t.Run("EmptySet", func(t *testing.T) {
+		valSet := makeValidatorSet(0)
+
+		val := valSet.Assign(commitment, 0)
+		require.Nil(t, val)
+	})
+
+	t.Run("SingleValidator", func(t *testing.T) {
+		valSet := makeValidatorSet(1)
+
+		for i := range 10 {
+			assignedVal := valSet.Assign(commitment, i)
+			require.NotNil(t, assignedVal)
+			require.Equal(t, valSet.Validators[0].Address.String(), assignedVal.Address.String())
+		}
+	})
+
+	t.Run("Distribution", func(t *testing.T) {
+		valSet := makeValidatorSet(100)
+
+		hasher := sha256.New()
+		hasher.Write([]byte("distribution-test"))
+		var distCommitment rsema1d.Commitment
+		copy(distCommitment[:], hasher.Sum(nil))
+
+		counts := make(map[string]int)
+		totalRows := 16384
+
+		for i := range totalRows {
+			val := valSet.Assign(distCommitment, i)
+			counts[val.Address.String()]++
+		}
+
+		expectedPerValidator := totalRows / len(valSet.Validators)
+		require.Equal(t, len(valSet.Validators), len(counts))
+
+		lowest, highest := totalRows, 0
+		for _, count := range counts {
+			if count < lowest {
+				lowest = count
+			}
+			if count > highest {
+				highest = count
+			}
+			require.GreaterOrEqual(t, count, expectedPerValidator)
+			require.LessOrEqual(t, count, expectedPerValidator+1)
+		}
+		t.Logf("Lowest assignments: %d, Highest assignments: %d", lowest, highest)
+	})
+
+	t.Run("Determinism", func(t *testing.T) {
+		valSet := makeValidatorSet(3)
+
+		numRows := 50
+		firstRun := make([]*core.Validator, numRows)
+		for i := range numRows {
+			firstRun[i] = valSet.Assign(commitment, i)
+		}
+
+		for i := range numRows {
+			val := valSet.Assign(commitment, i)
+			require.Equal(t, firstRun[i].Address.String(), val.Address.String())
+		}
+	})
+}
+
+func makeValidatorSet(n int) validator.Set {
+	validators := make([]*core.Validator, n)
+	for i := range n {
+		privKey := ed25519.GenPrivKey()
+		validators[i] = core.NewValidator(privKey.PubKey(), 1)
+	}
+	return validator.Set{
+		ValidatorSet: core.NewValidatorSet(validators),
+		Height:       100,
+	}
+}


### PR DESCRIPTION
~This diverges from the spec by not being called or abstracted away as a `ShardMap`. In practice, we won't have multiple algorithms implemented simultaneously and new ones will simply replace the older ones. 
This is also implemented as a method on `Set` structure rather then a separate component. A separate component is unnecessary as there is no state that the component would maintain and assigning is a pure function. Once we decide on the final assigning, we can simply rewrite the method as needed and update the respective usage code.~

The above is no longer true. The `ShardMap` type was added which holds validator to indexes assignments as per spec. Originally the idea was to individually select validators, but as it turns out it is impossible thus we need add the whole map.
