### PR TITLE
feat(x/fibre/types): grpc client cache and ctor

### DIFF
--- a/x/fibre/types/client_cache.go
+++ b/x/fibre/types/client_cache.go
@@ -1,0 +1,70 @@
+package types
+
+import (
+	"context"
+	"errors"
+	"sync"
+
+	core "github.com/cometbft/cometbft/types"
+)
+
+// ClientCache caches [FibreClientCloser]s per validator using the provided constructor function.
+// TODO(@Wondertan): Needs cleanup strategy, e.g. LRU
+type ClientCache struct {
+	newClient FibreClientCloserFn
+	mu        sync.Mutex
+	clients   map[string]*clientEntry // keyed by validator address string
+}
+
+// clientEntry holds a lazily-initialized [FibreClientCloser].
+type clientEntry struct {
+	sync.Once
+	clientCloser FibreClientCloser
+	err          error
+}
+
+// NewClientCache creates a new [ClientCache] with the given [FibreClientCloserFn].
+func NewClientCache(newClient FibreClientCloserFn) *ClientCache {
+	return &ClientCache{
+		newClient: newClient,
+		clients:   make(map[string]*clientEntry),
+	}
+}
+
+// GetClient returns a cached [FibreClient] for the validator, creating one if needed.
+// Uses the constructor function provided to [NewClientCache]. Only one dial per validator will occur.
+func (cc *ClientCache) GetClient(ctx context.Context, val *core.Validator) (FibreClient, error) {
+	addr := val.Address.String()
+
+	cc.mu.Lock()
+	entry, ok := cc.clients[addr]
+	if !ok {
+		entry = &clientEntry{}
+		cc.clients[addr] = entry
+	}
+	cc.mu.Unlock()
+
+	entry.Do(func() {
+		client, err := cc.newClient(ctx, val)
+		if err != nil {
+			entry.err = err
+			return
+		}
+		entry.clientCloser = client
+	})
+
+	return entry.clientCloser, entry.err
+}
+
+// Close closes all cached [FibreClientCloser]s.
+func (cc *ClientCache) Close() (err error) {
+	cc.mu.Lock()
+	defer cc.mu.Unlock()
+	for _, entry := range cc.clients {
+		if entry.clientCloser != nil {
+			err = errors.Join(err, entry.clientCloser.Close())
+		}
+	}
+	cc.clients = make(map[string]*clientEntry)
+	return err
+}

--- a/x/fibre/types/client_cache.go
+++ b/x/fibre/types/client_cache.go
@@ -8,23 +8,23 @@ import (
 	core "github.com/cometbft/cometbft/types"
 )
 
-// ClientCache caches [FibreClientCloser]s per validator using the provided constructor function.
+// ClientCache caches [Client]s per validator using the provided constructor function.
 // TODO(@Wondertan): Needs cleanup strategy, e.g. LRU
 type ClientCache struct {
-	newClient FibreClientCloserFn
+	newClient NewClientFn
 	mu        sync.Mutex
 	clients   map[string]*clientEntry // keyed by validator address string
 }
 
-// clientEntry holds a lazily-initialized [FibreClientCloser].
+// clientEntry holds a lazily-initialized [Client].
 type clientEntry struct {
 	sync.Once
-	clientCloser FibreClientCloser
+	clientCloser Client
 	err          error
 }
 
-// NewClientCache creates a new [ClientCache] with the given [FibreClientCloserFn].
-func NewClientCache(newClient FibreClientCloserFn) *ClientCache {
+// NewClientCache creates a new [ClientCache] with the given [NewClientFn].
+func NewClientCache(newClient NewClientFn) *ClientCache {
 	return &ClientCache{
 		newClient: newClient,
 		clients:   make(map[string]*clientEntry),
@@ -56,7 +56,7 @@ func (cc *ClientCache) GetClient(ctx context.Context, val *core.Validator) (Fibr
 	return entry.clientCloser, entry.err
 }
 
-// Close closes all cached [FibreClientCloser]s.
+// Close closes all cached [Client]s.
 func (cc *ClientCache) Close() (err error) {
 	cc.mu.Lock()
 	defer cc.mu.Unlock()

--- a/x/fibre/types/client_cache_test.go
+++ b/x/fibre/types/client_cache_test.go
@@ -1,0 +1,95 @@
+package types_test
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/celestiaorg/celestia-app/v6/x/fibre/types"
+	core "github.com/cometbft/cometbft/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClientCache(t *testing.T) {
+	const numGoroutines = 20
+	validators := []*core.Validator{
+		{
+			Address: []byte("validator-1"),
+		},
+		{
+			Address: []byte("validator-2"),
+		},
+	}
+	cache := types.NewClientCache(mockClientFn(false))
+
+	clients := make([]types.FibreClient, numGoroutines)
+	errors := make([]error, numGoroutines)
+
+	// concurrently get clients for multiple validators
+	var wg sync.WaitGroup
+	wg.Add(numGoroutines)
+	for i := range numGoroutines {
+		go func(idx int) {
+			defer wg.Done()
+			// each goroutine requests a client from a validator (round-robin)
+			val := validators[idx%len(validators)]
+			clients[idx], errors[idx] = cache.GetClient(t.Context(), val)
+		}(i)
+	}
+	wg.Wait()
+
+	// all should succeed
+	for i := range numGoroutines {
+		require.NoError(t, errors[i])
+		require.NotNil(t, clients[i])
+	}
+
+	// clients for the same validator should be identical
+	for i := range numGoroutines {
+		for j := i + 1; j < numGoroutines; j++ {
+			if i%len(validators) == j%len(validators) {
+				assert.Equal(t, clients[i], clients[j], "clients for same validator should be identical")
+			} else {
+				assert.NotEqual(t, clients[i], clients[j], "clients for different validators should be different")
+			}
+		}
+	}
+
+	// verify none are closed yet
+	mockClient1 := clients[0].(*mockFibreClientCloser)
+	mockClient2 := clients[1].(*mockFibreClientCloser)
+	assert.False(t, mockClient1.closed)
+	assert.False(t, mockClient2.closed)
+
+	// close should succeed and close all clients
+	err := cache.Close()
+	assert.NoError(t, err)
+	assert.True(t, mockClient1.closed)
+	assert.True(t, mockClient2.closed)
+}
+
+// mockFibreClientCloser is a mock implementation for testing
+type mockFibreClientCloser struct {
+	types.FibreClient
+	closed bool
+	id     string // unique identifier for this client
+}
+
+func (m *mockFibreClientCloser) Close() error {
+	m.closed = true
+	return nil
+}
+
+// mockClientFn creates a mock types.FibreClientCloserFn for testing
+func mockClientFn(shouldErr bool) types.FibreClientCloserFn {
+	return func(ctx context.Context, val *core.Validator) (types.FibreClientCloser, error) {
+		if shouldErr {
+			return nil, errors.New("mock client creation error")
+		}
+		return &mockFibreClientCloser{
+			id: val.Address.String(), // use validator address as unique id
+		}, nil
+	}
+}

--- a/x/fibre/types/client_cache_test.go
+++ b/x/fibre/types/client_cache_test.go
@@ -82,9 +82,9 @@ func (m *mockFibreClientCloser) Close() error {
 	return nil
 }
 
-// mockClientFn creates a mock types.FibreClientCloserFn for testing
-func mockClientFn(shouldErr bool) types.FibreClientCloserFn {
-	return func(ctx context.Context, val *core.Validator) (types.FibreClientCloser, error) {
+// mockClientFn creates a mock types.NewClientFn for testing
+func mockClientFn(shouldErr bool) types.NewClientFn {
+	return func(ctx context.Context, val *core.Validator) (types.Client, error) {
 		if shouldErr {
 			return nil, errors.New("mock client creation error")
 		}

--- a/x/fibre/types/fibre_client.go
+++ b/x/fibre/types/fibre_client.go
@@ -1,0 +1,59 @@
+package types
+
+import (
+	"context"
+	"io"
+
+	"github.com/celestiaorg/celestia-app/v6/x/fibre/validator"
+	core "github.com/cometbft/cometbft/types"
+	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+// FibreClientCloser combines [FibreClient] with [io.Closer] to manage the lifecycle
+// of both the client and its underlying connection.
+type FibreClientCloser interface {
+	FibreClient
+	io.Closer
+}
+
+// FibreClientCloserFn is a constructor function that creates a [FibreClientCloser]
+// for a given validator. It should handle host resolution and connection establishment.
+type FibreClientCloserFn func(ctx context.Context, val *core.Validator) (FibreClientCloser, error)
+
+// fibreClientCloser wraps a [FibreClient] and [grpc.ClientConn] to implement [FibreClientCloser].
+type fibreClientCloser struct {
+	FibreClient
+	conn *grpc.ClientConn
+}
+
+func (f *fibreClientCloser) Close() error {
+	return f.conn.Close()
+}
+
+// DefaultFibreClientFn returns the default [FibreClientCloserFn] that uses the provided
+// [validator.HostRegistry] to resolve validator hosts and establishes insecure gRPC connections
+// with OpenTelemetry instrumentation for distributed tracing.
+func DefaultFibreClientFn(hostReg validator.HostRegistry) FibreClientCloserFn {
+	return func(ctx context.Context, val *core.Validator) (FibreClientCloser, error) {
+		host, err := hostReg.GetHost(ctx, val)
+		if err != nil {
+			return nil, err
+		}
+
+		// TODO(@Wondertan): setup secure connection
+		conn, err := grpc.NewClient(host.String(),
+			grpc.WithTransportCredentials(insecure.NewCredentials()),
+			grpc.WithStatsHandler(otelgrpc.NewClientHandler()),
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		return &fibreClientCloser{
+			FibreClient: NewFibreClient(conn),
+			conn:        conn,
+		}, nil
+	}
+}

--- a/x/fibre/types/fibre_client.go
+++ b/x/fibre/types/fibre_client.go
@@ -11,18 +11,18 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 )
 
-// FibreClientCloser combines [FibreClient] with [io.Closer] to manage the lifecycle
+// Client combines [FibreClient] with [io.Closer] to manage the lifecycle
 // of both the client and its underlying connection.
-type FibreClientCloser interface {
+type Client interface {
 	FibreClient
 	io.Closer
 }
 
-// FibreClientCloserFn is a constructor function that creates a [FibreClientCloser]
+// NewClientFn is a constructor function that creates a [Client]
 // for a given validator. It should handle host resolution and connection establishment.
-type FibreClientCloserFn func(ctx context.Context, val *core.Validator) (FibreClientCloser, error)
+type NewClientFn func(ctx context.Context, val *core.Validator) (Client, error)
 
-// fibreClientCloser wraps a [FibreClient] and [grpc.ClientConn] to implement [FibreClientCloser].
+// fibreClientCloser wraps a [FibreClient] and [grpc.ClientConn] to implement [Client].
 type fibreClientCloser struct {
 	FibreClient
 	conn *grpc.ClientConn
@@ -32,11 +32,11 @@ func (f *fibreClientCloser) Close() error {
 	return f.conn.Close()
 }
 
-// DefaultFibreClientFn returns the default [FibreClientCloserFn] that uses the provided
+// DefaultFibreClientFn returns the default [NewClientFn] that uses the provided
 // [validator.HostRegistry] to resolve validator hosts and establishes insecure gRPC connections
 // with OpenTelemetry instrumentation for distributed tracing.
-func DefaultFibreClientFn(hostReg validator.HostRegistry) FibreClientCloserFn {
-	return func(ctx context.Context, val *core.Validator) (FibreClientCloser, error) {
+func DefaultFibreClientFn(hostReg validator.HostRegistry) NewClientFn {
+	return func(ctx context.Context, val *core.Validator) (Client, error) {
 		host, err := hostReg.GetHost(ctx, val)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
We need to cache/pool grpc clients and connections on the client side, so we don't reconnect all the time. The cache doesn't have any GC yet for when there are too many validator connections. 

Besides, a new function type was introduced that constructs the client and connection which is useful for mocking. The default one constructs insecure connection with support for OTLP traces that client and server integrate from day 0.

The insecure connection is something that we should not forget to change, until its too late. TLS + self signed certificates, unless we want to depend on centralized certificate authorities... (Also worth linking: https://github.com/open-telemetry/opentelemetry-go/issues/6661)

Also, these do not need to be part of `types` pkg but we sort of have to in order to avoid cycles