### PR TITLE
feat(x/fibre): add `creation_timestamp` bounds validation

### DIFF
--- a/x/fibre/keeper/keeper.go
+++ b/x/fibre/keeper/keeper.go
@@ -310,13 +310,32 @@ func (k Keeper) ParseProcessedPaymentsByTimeKey(key []byte) (processedAt time.Ti
 
 // ValidatePaymentPromiseStateful performs stateful validation of a payment promise.
 // It checks:
-// 1. The payment promise has not already been processed
-// 2. The escrow account exists for the signer
-// 3. The escrow account has sufficient available balance
+// 1. The creation_timestamp is within valid bounds
+// 2. The payment promise has not already been processed
+// 3. The escrow account exists for the signer
+// 4. The escrow account has sufficient available balance
 //
 // This method does NOT perform stateless validation.
 // Callers should perform stateless validation separately via pp.Validate().
 func (k Keeper) ValidatePaymentPromiseStateful(ctx sdk.Context, promise *types.PaymentPromise) error {
+	// Validate creation_timestamp bounds
+	// Spec requirement: creation_timestamp <= current confirmed timestamp
+	// and creation_timestamp > (header_timestamp - withdrawal_delay)
+	params := k.GetParams(ctx)
+	currentTime := ctx.BlockTime()
+	creationTime := promise.CreationTimestamp
+
+	// Check creation_timestamp is not in the future
+	if creationTime.After(currentTime) {
+		return fmt.Errorf("creation_timestamp %v is greater than current timestamp %v", creationTime, currentTime)
+	}
+
+	// Check creation_timestamp is not too old (must be greater than header_timestamp - withdrawal_delay)
+	minAllowedTime := currentTime.Add(-params.WithdrawalDelay)
+	if !creationTime.After(minAllowedTime) {
+		return fmt.Errorf("creation_timestamp %v must be greater than %v (current_time - withdrawal_delay)", creationTime, minAllowedTime)
+	}
+
 	// Check if payment promise has already been processed
 	if isAlreadyProcessed := k.IsPaymentPromiseProcessed(ctx, promise); isAlreadyProcessed {
 		return fmt.Errorf("payment promise has already been processed")
@@ -331,7 +350,6 @@ func (k Keeper) ValidatePaymentPromiseStateful(ctx sdk.Context, promise *types.P
 	}
 
 	// Check sufficient available balance
-	params := k.GetParams(ctx)
 	gasRequired := uint64(promise.BlobSize) * uint64(params.GasPerBlobByte)
 
 	// TODO: This assumes 1 gas = 1 utia but the minimum gas price could be

--- a/x/fibre/keeper/keeper_test.go
+++ b/x/fibre/keeper/keeper_test.go
@@ -462,6 +462,41 @@ func (suite *KeeperTestSuite) TestValidatePaymentPromiseInternal() {
 	})
 }
 
+func (suite *KeeperTestSuite) TestValidatePaymentPromiseStateful() {
+	suite.T().Run("payment promise with future creation timestamp should be rejected", func(t *testing.T) {
+		paymentPromise := suite.createPaymentPromise()
+		suite.createEscrowAccount(paymentPromise)
+
+		// Set creation timestamp to the future
+		paymentPromise.CreationTimestamp = suite.ctx.BlockTime().Add(1 * time.Hour)
+
+		// Validate should fail because creation timestamp is in the future
+		err := suite.keeper.ValidatePaymentPromiseStateful(suite.ctx, &paymentPromise)
+		suite.Error(err)
+		suite.Contains(err.Error(), "creation_timestamp")
+		suite.Contains(err.Error(), "greater than current timestamp")
+	})
+
+	suite.T().Run("payment promise with timestamp before withdrawal delay should be rejected", func(t *testing.T) {
+		paymentPromise := suite.createPaymentPromise()
+		suite.createEscrowAccount(paymentPromise)
+
+		params := suite.keeper.GetParams(suite.ctx)
+		currentTime := suite.ctx.BlockTime()
+
+		// Set creation timestamp to be older than (currentTime - withdrawalDelay)
+		// This means it's too old and should be rejected
+		paymentPromise.CreationTimestamp = currentTime.Add(-params.WithdrawalDelay).Add(-1 * time.Second)
+
+		// Validate should fail because creation timestamp is too old
+		err := suite.keeper.ValidatePaymentPromiseStateful(suite.ctx, &paymentPromise)
+		suite.Error(err)
+		suite.Contains(err.Error(), "creation_timestamp")
+		suite.Contains(err.Error(), "must be greater than")
+		suite.Contains(err.Error(), "current_time - withdrawal_delay")
+	})
+}
+
 // createPaymentPromise creates a properly signed and valid payment promise for testing
 func (suite *KeeperTestSuite) createPaymentPromise() types.PaymentPromise {
 	privKey := secp256k1.GenPrivKey()

--- a/x/fibre/types/msgs_test.go
+++ b/x/fibre/types/msgs_test.go
@@ -324,6 +324,21 @@ func TestPaymentPromiseValidateBasic(t *testing.T) {
 			},
 			wantErr: sdkerrors.ErrInvalidRequest,
 		},
+		{
+			name: "zero creation timestamp",
+			msg: PaymentPromise{
+				SignerPublicKey:   signerPublicKey,
+				Namespace:         namespace,
+				BlobSize:          blobSize,
+				Commitment:        commitment,
+				BlobVersion:       blobVersion,
+				CreationTimestamp: time.Time{}, // zero time
+				Signature:         signature,
+				Height:            height,
+				ChainId:           chainId,
+			},
+			wantErr: sdkerrors.ErrInvalidRequest,
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
This adds validation on the `creation_timestamp` to match the spec: https://github.com/celestiaorg/fibre-da-spec/blob/489eab8ebb055fb0c82054249d74cb6624801d6b/sdk_fibre_module.md?plain=1#L428-L431