### PR TITLE
feat(fibre/validator): GrpcSetGetter

### DIFF
--- a/fibre/validator/grpc_set_getter.go
+++ b/fibre/validator/grpc_set_getter.go
@@ -1,0 +1,66 @@
+package validator
+
+import (
+	"context"
+	"fmt"
+
+	coregrpc "github.com/cometbft/cometbft/rpc/grpc"
+	core "github.com/cometbft/cometbft/types"
+)
+
+// GrpcGetter implements the [SetGetter] interface by fetching [Set]
+// using the BlockAPI gRPC client.
+type GrpcGetter struct {
+	client coregrpc.BlockAPIClient
+}
+
+// NewGrpcGetter creates a new [GrpcGetter] instance with the provided BlockAPI gRPC client.
+func NewGrpcGetter(client coregrpc.BlockAPIClient) *GrpcGetter {
+	return &GrpcGetter{
+		client: client,
+	}
+}
+
+// Head returns the latest [Set] by calling getByHeight with 0 height.
+// This avoids an additional roundtrip to get the status first.
+func (g *GrpcGetter) Head(ctx context.Context) (Set, error) {
+	return g.getByHeight(ctx, 0)
+}
+
+// GetByHeight returns the [Set] at the specified height.
+// Height must be greater than 0. Use [GrpcGetter.Head] to get the latest [Set].
+// TODO(@Wondertan): Ensure that server side can handle head+1 case gracefully
+func (g *GrpcGetter) GetByHeight(ctx context.Context, height uint64) (Set, error) {
+	if height == 0 {
+		return Set{}, fmt.Errorf("height must be greater than 0, use Head() to get the latest validator set")
+	}
+	return g.getByHeight(ctx, height)
+}
+
+// getByHeight is the private implementation that allows 0 height for latest validator set.
+func (g *GrpcGetter) getByHeight(ctx context.Context, height uint64) (Set, error) {
+	signedHeight := int64(height)
+
+	// fetch the validator set for this height (0 means latest)
+	validatorResp, err := g.client.ValidatorSet(ctx, &coregrpc.ValidatorSetRequest{
+		Height: signedHeight,
+	})
+	if err != nil {
+		return Set{}, fmt.Errorf("getting validator set at height %d: %w", height, err)
+	}
+	if validatorResp.ValidatorSet == nil {
+		return Set{}, fmt.Errorf("validator set is nil in response for height %d", height)
+	}
+
+	validatorSet, err := core.ValidatorSetFromProto(validatorResp.ValidatorSet)
+	if err != nil {
+		return Set{}, fmt.Errorf("converting validator set from proto at height %d: %w", height, err)
+	}
+
+	return Set{
+		ValidatorSet: validatorSet,
+		Height:       uint64(validatorResp.Height),
+	}, nil
+}
+
+var _ SetGetter = (*GrpcGetter)(nil)

--- a/fibre/validator/grpc_set_getter_test.go
+++ b/fibre/validator/grpc_set_getter_test.go
@@ -1,0 +1,113 @@
+package validator_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/celestiaorg/celestia-app/v6/fibre/validator"
+
+	cmted25519 "github.com/cometbft/cometbft/crypto/ed25519"
+	coregrpc "github.com/cometbft/cometbft/rpc/grpc"
+	core "github.com/cometbft/cometbft/types"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+)
+
+func TestGrpcGetter_GetByHeight_Success(t *testing.T) {
+	const testHeight = uint64(100)
+
+	// Create test validators
+	validators := makeTestValidators(t, 3)
+	valSet := core.NewValidatorSet(validators)
+
+	// Convert to proto for the response
+	valSetProto, err := valSet.ToProto()
+	require.NoError(t, err)
+
+	// Create mock client that returns the validator set
+	mockClient := &mockValidatorSetClient{
+		response: &coregrpc.ValidatorSetResponse{
+			ValidatorSet: valSetProto,
+			Height:       int64(testHeight),
+		},
+	}
+
+	// Create getter and fetch validator set
+	getter := validator.NewGrpcGetter(mockClient)
+	result, err := getter.GetByHeight(context.Background(), testHeight)
+
+	// Verify results
+	require.NoError(t, err)
+	require.Equal(t, testHeight, result.Height)
+	require.NotNil(t, result.ValidatorSet)
+	require.Len(t, result.Validators, 3)
+	require.Equal(t, int64(300), result.TotalVotingPower()) // 3 validators * 100 voting power each
+}
+
+func TestGrpcGetter_GetByHeight_ZeroHeight(t *testing.T) {
+	// Test that GetByHeight rejects zero height
+	var client coregrpc.BlockAPIClient
+	getter := validator.NewGrpcGetter(client)
+
+	_, err := getter.GetByHeight(context.Background(), 0)
+	if err == nil {
+		t.Error("GetByHeight should reject zero height")
+	}
+	if err.Error() != "height must be greater than 0, use Head() to get the latest validator set" {
+		t.Errorf("Expected specific error message, got: %v", err)
+	}
+}
+
+// makeTestValidators creates n validators for testing.
+func makeTestValidators(t *testing.T, n int) []*core.Validator {
+	t.Helper()
+	validators := make([]*core.Validator, n)
+	for i := range n {
+		privKey := cmted25519.GenPrivKey()
+		validators[i] = &core.Validator{
+			Address:     privKey.PubKey().Address(),
+			PubKey:      privKey.PubKey(),
+			VotingPower: 100,
+		}
+	}
+	return validators
+}
+
+// mockValidatorSetClient mocks the ValidatorSet method for testing.
+type mockValidatorSetClient struct {
+	MockBlockAPIClient
+	response *coregrpc.ValidatorSetResponse
+}
+
+func (m *mockValidatorSetClient) ValidatorSet(ctx context.Context, req *coregrpc.ValidatorSetRequest, opts ...grpc.CallOption) (*coregrpc.ValidatorSetResponse, error) {
+	return m.response, nil
+}
+
+// MockBlockAPIClient is a simple mock for testing interface compliance
+type MockBlockAPIClient struct {
+	coregrpc.UnimplementedBlockAPIServer
+}
+
+func (m *MockBlockAPIClient) Status(ctx context.Context, req *coregrpc.StatusRequest, opts ...grpc.CallOption) (*coregrpc.StatusResponse, error) {
+	return &coregrpc.StatusResponse{}, nil
+}
+
+func (m *MockBlockAPIClient) Commit(ctx context.Context, req *coregrpc.CommitRequest, opts ...grpc.CallOption) (*coregrpc.CommitResponse, error) {
+	return &coregrpc.CommitResponse{}, nil
+}
+
+func (m *MockBlockAPIClient) ValidatorSet(ctx context.Context, req *coregrpc.ValidatorSetRequest, opts ...grpc.CallOption) (*coregrpc.ValidatorSetResponse, error) {
+	return &coregrpc.ValidatorSetResponse{}, nil
+}
+
+func (m *MockBlockAPIClient) BlockByHeight(ctx context.Context, req *coregrpc.BlockByHeightRequest, opts ...grpc.CallOption) (coregrpc.BlockAPI_BlockByHeightClient, error) {
+	return nil, nil // For now, just return nil to test interface compliance
+}
+
+func (m *MockBlockAPIClient) BlockByHash(ctx context.Context, req *coregrpc.BlockByHashRequest, opts ...grpc.CallOption) (coregrpc.BlockAPI_BlockByHashClient, error) {
+	return nil, nil
+}
+
+func (m *MockBlockAPIClient) SubscribeNewHeights(ctx context.Context, req *coregrpc.SubscribeNewHeightsRequest, opts ...grpc.CallOption) (coregrpc.BlockAPI_SubscribeNewHeightsClient, error) {
+	return nil, nil
+}


### PR DESCRIPTION
Allows fetching validator sets over GRPC. 

Handling the case where the requested height is head+1 is out of scope of this PR and should be handled on the core side. 