### PR TITLE
fix: register fibre module account

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -144,6 +144,7 @@ var maccPerms = map[string][]string{
 	icatypes.ModuleName:            nil,
 	hyperlanetypes.ModuleName:      nil,
 	warptypes.ModuleName:           {authtypes.Minter, authtypes.Burner},
+	fibretypes.ModuleName:          nil,
 }
 
 var (


### PR DESCRIPTION
The fibre module account was not registered in the maccPerms map.

```
Error Trace:    /Users/callum/Developer/go/src/github.com/celestiaorg/celestia-app-fibre/fibre/fibre_e2e_test.go:269                            
                Error:          Received unexpected error:
                                tx execution failed with code 111222: recovered: module account fibre does not exist: unknown address [celestiaorg/cosmos-sdk@v0.51.3/x/bank/keeper/keeper.go:299]  
```