### PR TITLE
fix: go lint issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,18 +195,20 @@ This repository includes dependencies on private GitHub repositories. To build t
 
 2. **Configure Git authentication**:
    Add the following line to your `$HOME/.netrc` file (create it if it doesn't exist):
-   
-   ```
+
+   ```ascii
    machine github.com login <YOUR_GITHUB_USERNAME> password <YOUR_GITHUB_PAT_TOKEN>
    ```
-   
+
    **Important**: Replace `<YOUR_GITHUB_USERNAME>` with your actual GitHub username and `<YOUR_GITHUB_PAT_TOKEN>` with the token you generated in step 1.
 
-   **Security Notes**: 
+   **Security Notes**:
    - Ensure your `.netrc` file has appropriate permissions:
+
      ```shell
      chmod 600 ~/.netrc
      ```
+
    - Never commit your `.netrc` file to version control as it contains sensitive credentials
    - Verify that `~/.netrc` is in your global `.gitignore` or the repository's `.gitignore`
 

--- a/fibre/client_server_upload_test.go
+++ b/fibre/client_server_upload_test.go
@@ -2,8 +2,8 @@ package fibre_test
 
 import (
 	"context"
+	"crypto/rand"
 	"fmt"
-	"math/rand"
 	"testing"
 
 	"github.com/celestiaorg/celestia-app/v6/fibre"
@@ -36,7 +36,7 @@ func TestClientServerUpload(t *testing.T) {
 	err := env.ForEachClient(t.Context(), func(ctx context.Context, client *fibre.Client, clientIdx int) error {
 		for blobIdx := range blobsPerClient {
 			data := make([]byte, blobSize)
-			if _, err := rand.Read(data); err != nil { //nolint:staticcheck
+			if _, err := rand.Read(data); err != nil {
 				return fmt.Errorf("generating random data for blob %d: %w", blobIdx, err)
 			}
 

--- a/fibre/server_upload.go
+++ b/fibre/server_upload.go
@@ -182,7 +182,7 @@ func (s *Server) verifyAssignment(ctx context.Context, promise *PaymentPromise, 
 // verifyRows verifies the row data and proofs using [rsema1d.VerificationContext].
 // Essentially checks correctness of blob data by only sampling some of the rows.
 // Sets the RLC root on the rows and clears the coefficients after verification.
-func (s *Server) verifyRows(ctx context.Context, promise *PaymentPromise, rows *types.Rows) error {
+func (s *Server) verifyRows(_ context.Context, promise *PaymentPromise, rows *types.Rows) error {
 	rowSize, err := parseRowSize(rows.Rows)
 	if err != nil {
 		return err

--- a/x/fibre/keeper/keeper.go
+++ b/x/fibre/keeper/keeper.go
@@ -7,7 +7,7 @@ import (
 	"cosmossdk.io/log"
 	"cosmossdk.io/math"
 	storetypes "cosmossdk.io/store/types"
-	fibre "github.com/celestiaorg/celestia-app/v6/fibre"
+	"github.com/celestiaorg/celestia-app/v6/fibre"
 	"github.com/celestiaorg/celestia-app/v6/x/fibre/types"
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -233,7 +233,9 @@ func (k Keeper) DeleteProcessedPayment(ctx sdk.Context, payment types.ProcessedP
 func (k Keeper) IsPaymentPromiseProcessed(ctx sdk.Context, promise *types.PaymentPromise) bool {
 	store := ctx.KVStore(k.storeKey)
 	pp := fibre.PaymentPromise{}
-	pp.FromProto(promise)
+	if err := pp.FromProto(promise); err != nil {
+		return false
+	}
 	hash, err := pp.Hash()
 	if err != nil {
 		return false

--- a/x/fibre/keeper/keeper_test.go
+++ b/x/fibre/keeper/keeper_test.go
@@ -10,7 +10,7 @@ import (
 	"cosmossdk.io/store"
 	"cosmossdk.io/store/metrics"
 	storetypes "cosmossdk.io/store/types"
-	fibre "github.com/celestiaorg/celestia-app/v6/fibre"
+	"github.com/celestiaorg/celestia-app/v6/fibre"
 	"github.com/celestiaorg/celestia-app/v6/x/fibre/keeper"
 	"github.com/celestiaorg/celestia-app/v6/x/fibre/types"
 	"github.com/celestiaorg/go-square/v3/share"
@@ -292,7 +292,8 @@ func (suite *KeeperTestSuite) TestProcessedPayment() {
 	suite.T().Run("isPaymentProcessed should return true for existing payment promise", func(t *testing.T) {
 		paymentPromise := suite.createPaymentPromise()
 		pp := fibre.PaymentPromise{}
-		pp.FromProto(&paymentPromise)
+		err := pp.FromProto(&paymentPromise)
+		suite.NoError(err)
 		paymentPromiseHash, err := pp.Hash()
 		suite.NoError(err)
 

--- a/x/fibre/keeper/msg_server.go
+++ b/x/fibre/keeper/msg_server.go
@@ -5,7 +5,7 @@ import (
 
 	errorsmod "cosmossdk.io/errors"
 	"cosmossdk.io/math"
-	fibre "github.com/celestiaorg/celestia-app/v6/fibre"
+	"github.com/celestiaorg/celestia-app/v6/fibre"
 	"github.com/celestiaorg/celestia-app/v6/fibre/validator"
 	"github.com/celestiaorg/celestia-app/v6/pkg/appconsts"
 	"github.com/celestiaorg/celestia-app/v6/x/fibre/types"

--- a/x/fibre/keeper/msg_server_test.go
+++ b/x/fibre/keeper/msg_server_test.go
@@ -11,7 +11,7 @@ import (
 	"cosmossdk.io/store"
 	"cosmossdk.io/store/metrics"
 	storetypes "cosmossdk.io/store/types"
-	fibre "github.com/celestiaorg/celestia-app/v6/fibre"
+	"github.com/celestiaorg/celestia-app/v6/fibre"
 	"github.com/celestiaorg/celestia-app/v6/pkg/appconsts"
 	"github.com/celestiaorg/celestia-app/v6/x/fibre/keeper"
 	"github.com/celestiaorg/celestia-app/v6/x/fibre/types"


### PR DESCRIPTION
Fixes a bunch of golangci-lint issues. Not sure how/why these merged to feature/fibre.

Update: looks like CI isn't running checks after PRs merge to feature/fibre. And they're not run on this PR.

## Testing

```
make lint
# passes go lint
```

There are a bunch of markdownlint failures but those seem present on celestia-app too.