### PR TITLE
fix(fibre): grpc support for large blobs

### DIFF
--- a/cmd/celestia-appd/cmd/start_command_standalone.go
+++ b/cmd/celestia-appd/cmd/start_command_standalone.go
@@ -109,6 +109,9 @@ func startCommandHandler(
 		if err != nil {
 			return fmt.Errorf("failed to start Fibre server: %w", err)
 		}
+		maxMsgSize := fibre.MaxMessageSize(serverConfig.BlobConfig)
+		svrCfg.GRPC.MaxRecvMsgSize = maxMsgSize
+		svrCfg.GRPC.MaxSendMsgSize = maxMsgSize
 
 		// Now start the gRPC server (after all services are registered)
 		if err := startGRPCServer(ctx, g, svrCtx, svrCfg, grpcServer, cmtNode); err != nil {

--- a/fibre/blob.go
+++ b/fibre/blob.go
@@ -1,6 +1,7 @@
 package fibre
 
 import (
+	"crypto/sha256"
 	"encoding/binary"
 	"encoding/hex"
 	"errors"
@@ -52,17 +53,22 @@ type BlobConfig struct {
 	BlobVersion uint8
 	// CodingWorkers is the number of workers to use for encoding and decoding rsema1d.
 	CodingWorkers int
+	// ShardingFactor is the expected number of validators in the network.
+	// This is used to calculate the maximum gRPC message size per validator.
+	// Should be set to match the expected validator set size.
+	ShardingFactor int
 }
 
 // DefaultBlobConfigV0 returns a [BlobConfig] with default values for version 0.
 func DefaultBlobConfigV0() BlobConfig {
 	return BlobConfig{
-		OriginalRows:  4096,
-		ParityRows:    12288, // (3 * OriginalRows, TotalRows = 16384)
-		RowSizeMin:    64,
-		MaxBlobSize:   128 * 1024 * 1024,
-		BlobVersion:   0,
-		CodingWorkers: runtime.GOMAXPROCS(0),
+		OriginalRows:   4096,
+		ParityRows:     12288, // (3 * OriginalRows, TotalRows = 16384)
+		RowSizeMin:     64,
+		MaxBlobSize:    128 * 1024 * 1024,
+		BlobVersion:    0,
+		CodingWorkers:  runtime.GOMAXPROCS(0),
+		ShardingFactor: 100, // Expected number of validators
 	}
 }
 
@@ -95,6 +101,33 @@ func (c BlobConfig) MaxRowSize() int {
 // This is the size included in the [PaymentPromise] and the one actually paid for.
 func (c BlobConfig) UploadSize(dataLen int) int {
 	return c.RowSize(dataLen) * c.OriginalRows
+}
+
+// MaxShardSize calculates the maximum size of a shard (subset of blob rows assigned to a validator with RLC and Merkle proofs)
+// This does not include protocol overhead like PaymentPromise or protobuf encoding overhead.
+func (c BlobConfig) MaxShardSize() int {
+	const (
+		rowIndexSize = 4  // uint32 index per row
+		rlcCoeffSize = 16 // uint128 coefficient per row
+	)
+
+	totalRows := c.OriginalRows + c.ParityRows
+	maxRowSize := c.MaxRowSize()
+	rlcCoeffsSize := c.OriginalRows * rlcCoeffSize
+
+	// get proof size per row by finding merkle tree depth
+	treeDepth := 0
+	for n := totalRows; n > 1; n = (n + 1) / 2 {
+		treeDepth++
+	}
+	proofSizePerRow := treeDepth * sha256.Size
+
+	// calculate rows per validator based on sharding factor
+	// add 1 to account for potential uneven distribution
+	// TODO(@Wondertan): This is not completely accurate, but it's a good approximation for now.
+	rowsPerValidator := (totalRows / c.ShardingFactor) + 1
+
+	return rlcCoeffsSize + (rowsPerValidator * (rowIndexSize + maxRowSize + proofSizePerRow))
 }
 
 // Blob represents encoded data with Reed-Solomon erasure coding.

--- a/fibre/client.go
+++ b/fibre/client.go
@@ -109,7 +109,7 @@ func NewClient(txClient *user.TxClient, kr keyring.Keyring, valGet validator.Set
 	}
 
 	if cfg.NewClientFn == nil {
-		cfg.NewClientFn = grpc.DefaultNewClientFn(hostReg)
+		cfg.NewClientFn = grpc.DefaultNewClientFn(hostReg, MaxMessageSize(cfg.BlobConfig))
 	}
 	if cfg.Tracer == nil {
 		cfg.Tracer = otel.Tracer("fibre-client")
@@ -152,4 +152,10 @@ func (c *Client) Close() error {
 
 	c.closeWg.Wait()
 	return c.clientCache.Close()
+}
+
+// MaxMessageSize returns the maximum message size that can be sent over the network.
+func MaxMessageSize(cfg BlobConfig) int {
+	msgSize := cfg.MaxShardSize() + MaxPaymentPromiseSize
+	return msgSize + (msgSize / 50) // add 2% protobuf overhead
 }

--- a/fibre/client_server_test.go
+++ b/fibre/client_server_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net"
-	"path/filepath"
 	"testing"
 
 	"github.com/celestiaorg/celestia-app/v6/fibre"
@@ -13,12 +12,10 @@ import (
 	"github.com/celestiaorg/celestia-app/v6/fibre/validator"
 	"github.com/celestiaorg/celestia-app/v6/x/fibre/types"
 	cmted25519 "github.com/cometbft/cometbft/crypto/ed25519"
-	coregrpc "github.com/cometbft/cometbft/rpc/grpc"
 	core "github.com/cometbft/cometbft/types"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
 )
 
 // testEnv holds the test environment with servers, clients, and validator set
@@ -91,7 +88,7 @@ func makeTestEnv(
 	clients := make([]*fibre.Client, numClients)
 	for i := range numClients {
 		clientCfg := fibre.DefaultClientConfig()
-		clientCfg.NewClientFn = grpcfibre.DefaultNewClientFn(&testHostRegistry{addresses: addresses})
+		clientCfg.ShardingFactor = numValidators
 
 		// create logger with unique client identifier
 		clientCfg.Log = slog.Default().With("client_idx", i)
@@ -100,6 +97,7 @@ func makeTestEnv(
 		if modifyClientConfig != nil {
 			modifyClientConfig(&clientCfg)
 		}
+		clientCfg.NewClientFn = grpcfibre.DefaultNewClientFn(&testHostRegistry{addresses: addresses}, fibre.MaxMessageSize(clientCfg.BlobConfig))
 
 		client, err := fibre.NewClient(nil, makeTestKeyring(t), &mockValidatorSetGetter{set: valSet}, &mockHostRegistry{}, clientCfg)
 		require.NoError(t, err)
@@ -125,7 +123,6 @@ func makeTestServers(
 	t.Helper()
 
 	grpcServers := make([]*grpc.Server, len(validators))
-	fibreServers := make([]*fibre.Server, len(validators))
 	stores := make([]*fibre.Store, len(validators))
 	addresses := make(map[string]string)
 
@@ -134,9 +131,8 @@ func makeTestServers(
 		require.NoError(t, err)
 
 		serverCfg := fibre.DefaultServerConfig()
-		// Set a temporary directory for the BadgerDB store
-		tmpDir := t.TempDir()
-		serverCfg.Path = filepath.Join(tmpDir, "fibre-store")
+		serverCfg.ShardingFactor = len(validators)
+
 		// create logger with unique server identifier
 		serverCfg.Log = slog.Default().With(
 			"server_idx", i,
@@ -149,47 +145,24 @@ func makeTestServers(
 			modifyServerConfig(&serverCfg)
 		}
 
-		// Create gRPC server with mock services
-		grpcServer := grpc.NewServer()
-
-		// Register mock Query service
-		mockQueryServer := &mockQueryServer{}
-		types.RegisterQueryServer(grpcServer, mockQueryServer)
-
-		// Register mock BlockAPI service
-		valSetProto, err := valSet.ToProto()
-		require.NoError(t, err)
-		mockBlockAPIServer := &mockBlockAPIServer{
-			validatorSetResponse: &coregrpc.ValidatorSetResponse{
-				ValidatorSet: valSetProto,
-				Height:       int64(valSet.Height),
-			},
-		}
-		coregrpc.RegisterBlockAPIServer(grpcServer, mockBlockAPIServer)
-
-		// Create client connection to the mock server (will be used after server starts)
-		// Create connection before starting server
-		conn, err := grpc.NewClient(
-			listener.Addr().String(),
-			grpc.WithTransportCredentials(insecure.NewCredentials()),
-		)
-		require.NoError(t, err)
-
-		// Create Fibre server - this will register the Fibre service on grpcServer
-		fibreServer, err := fibre.NewServerFromGRPC(
+		fibreServer, err := fibre.NewInMemoryServer(
 			newTestPrivValidator(privKeys[i]),
-			grpcServer,
-			conn,
+			&mockQueryClient{},
+			&mockValidatorSetGetter{set: valSet},
 			serverCfg,
 		)
 		require.NoError(t, err)
 
-		// Now start the gRPC server after all services are registered
+		maxMsgSize := fibre.MaxMessageSize(fibreServer.Config().BlobConfig)
+		grpcServer := grpc.NewServer(
+			grpc.MaxRecvMsgSize(maxMsgSize),
+			grpc.MaxSendMsgSize(maxMsgSize),
+		)
+		types.RegisterFibreServer(grpcServer, fibreServer)
+
 		go func() { _ = grpcServer.Serve(listener) }()
 
 		grpcServers[i] = grpcServer
-		fibreServers[i] = fibreServer
-		// Extract store from server for test access
 		stores[i] = fibreServer.Store()
 		addresses[val.Address.String()] = listener.Addr().String()
 	}
@@ -208,40 +181,4 @@ func (r *testHostRegistry) GetHost(ctx context.Context, val *core.Validator) (va
 		return "", fmt.Errorf("no address for validator %s", val.Address.String())
 	}
 	return validator.Host(addr), nil
-}
-
-// mockQueryServer is a mock implementation of types.QueryServer for testing.
-type mockQueryServer struct {
-	types.UnimplementedQueryServer
-}
-
-func (m *mockQueryServer) Params(ctx context.Context, in *types.QueryParamsRequest) (*types.QueryParamsResponse, error) {
-	return &types.QueryParamsResponse{}, nil
-}
-
-func (m *mockQueryServer) EscrowAccount(ctx context.Context, in *types.QueryEscrowAccountRequest) (*types.QueryEscrowAccountResponse, error) {
-	return &types.QueryEscrowAccountResponse{}, nil
-}
-
-func (m *mockQueryServer) Withdrawals(ctx context.Context, in *types.QueryWithdrawalsRequest) (*types.QueryWithdrawalsResponse, error) {
-	return &types.QueryWithdrawalsResponse{}, nil
-}
-
-func (m *mockQueryServer) IsPaymentProcessed(ctx context.Context, in *types.QueryIsPaymentProcessedRequest) (*types.QueryIsPaymentProcessedResponse, error) {
-	return &types.QueryIsPaymentProcessedResponse{}, nil
-}
-
-func (m *mockQueryServer) ValidatePaymentPromise(ctx context.Context, in *types.QueryValidatePaymentPromiseRequest) (*types.QueryValidatePaymentPromiseResponse, error) {
-	// Always return valid for testing
-	return &types.QueryValidatePaymentPromiseResponse{IsValid: true}, nil
-}
-
-// mockBlockAPIServer is a mock implementation of coregrpc.BlockAPIServer for testing.
-type mockBlockAPIServer struct {
-	coregrpc.UnimplementedBlockAPIServer
-	validatorSetResponse *coregrpc.ValidatorSetResponse
-}
-
-func (m *mockBlockAPIServer) ValidatorSet(ctx context.Context, req *coregrpc.ValidatorSetRequest) (*coregrpc.ValidatorSetResponse, error) {
-	return m.validatorSetResponse, nil
 }

--- a/fibre/client_server_upload_test.go
+++ b/fibre/client_server_upload_test.go
@@ -22,7 +22,7 @@ func TestClientServerUpload(t *testing.T) {
 	}{
 		{
 			name:           "MaxBlobSize",
-			numValidators:  3,
+			numValidators:  1,
 			numClients:     2,
 			blobsPerClient: 1,
 			blobSize:       fibre.DefaultBlobConfigV0().MaxBlobSize,

--- a/fibre/client_server_upload_test.go
+++ b/fibre/client_server_upload_test.go
@@ -11,91 +11,117 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestClientServerUpload validates end-to-end upload flow at scale.
-// tests upload with 10 validators, 10 clients, and 5 blobs per client (50 total uploads).
+// TestClientServerUpload validates end-to-end over GRPC the upload flow with various blob sizes and configurations.
 func TestClientServerUpload(t *testing.T) {
-	const (
-		numValidators  = 10
-		numClients     = 10
-		blobsPerClient = 5
-		blobSize       = 128 * 1024 // 128 KiB
-	)
+	tests := []struct {
+		name           string
+		numValidators  int
+		numClients     int
+		blobsPerClient int
+		blobSize       int
+	}{
+		{
+			name:           "MaxBlobSize",
+			numValidators:  3,
+			numClients:     2,
+			blobsPerClient: 1,
+			blobSize:       fibre.DefaultBlobConfigV0().MaxBlobSize,
+		},
+		{
+			name:           "MinBlobSize",
+			numValidators:  3,
+			numClients:     2,
+			blobsPerClient: 1,
+			blobSize:       1,
+		},
+		{
+			name:           "ManyClientsManyServersManyBlobs",
+			numValidators:  10,
+			numClients:     10,
+			blobsPerClient: 5,
+			blobSize:       128 * 1024, // 128 KiB
+		},
+	}
 
-	env := makeTestEnv(t, numValidators, numClients, func(cfg *fibre.ClientConfig) {
-		// ensure all validators receive rows by setting target signatures to 100%
-		cfg.UploadTargetSignaturesCount.Numerator = 1
-		cfg.UploadTargetSignaturesCount.Denominator = 1
-	}, nil)
-	defer env.Close()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			env := makeTestEnv(t, tt.numValidators, tt.numClients, func(cfg *fibre.ClientConfig) {
+				// ensure all validators receive rows by setting target signatures to 100%
+				cfg.UploadTargetSignaturesCount.Numerator = 1
+				cfg.UploadTargetSignaturesCount.Denominator = 1
+			}, nil)
+			defer env.Close()
 
-	totalBlobs := numClients * blobsPerClient
-	allCommitments := make([]fibre.Commitment, totalBlobs)
-	allPromiseHashes := make([][]byte, totalBlobs)
+			totalBlobs := tt.numClients * tt.blobsPerClient
+			allCommitments := make([]fibre.Commitment, totalBlobs)
+			allPromiseHashes := make([][]byte, totalBlobs)
 
-	// for each client start uploading blobs
-	err := env.ForEachClient(t.Context(), func(ctx context.Context, client *fibre.Client, clientIdx int) error {
-		for blobIdx := range blobsPerClient {
-			data := make([]byte, blobSize)
-			if _, err := rand.Read(data); err != nil {
-				return fmt.Errorf("generating random data for blob %d: %w", blobIdx, err)
-			}
+			// for each client start uploading blobs
+			err := env.ForEachClient(t.Context(), func(ctx context.Context, client *fibre.Client, clientIdx int) error {
+				for blobIdx := range tt.blobsPerClient {
+					data := make([]byte, tt.blobSize)
+					if _, err := rand.Read(data); err != nil {
+						return fmt.Errorf("generating random data for blob %d: %w", blobIdx, err)
+					}
 
-			blob, err := fibre.NewBlob(data, client.Config().BlobConfig)
-			if err != nil {
-				return fmt.Errorf("creating blob %d: %w", blobIdx, err)
-			}
+					blob, err := fibre.NewBlob(data, client.Config().BlobConfig)
+					if err != nil {
+						return fmt.Errorf("creating blob %d: %w", blobIdx, err)
+					}
 
-			ns := share.MustNewV0Namespace([]byte{byte(clientIdx >> 8), byte(clientIdx)})
-			promise, err := client.Upload(ctx, ns, blob)
-			if err != nil {
-				return fmt.Errorf("uploading blob %d: %w", blobIdx, err)
-			}
-			promiseHash, err := promise.Hash()
-			if err != nil {
-				return fmt.Errorf("hashing payment promise %d: %w", blobIdx, err)
-			}
+					ns := share.MustNewV0Namespace([]byte{byte(clientIdx >> 8), byte(clientIdx)})
+					promise, err := client.Upload(ctx, ns, blob)
+					if err != nil {
+						return fmt.Errorf("uploading blob %d: %w", blobIdx, err)
+					}
+					promiseHash, err := promise.Hash()
+					if err != nil {
+						return fmt.Errorf("hashing payment promise %d: %w", blobIdx, err)
+					}
 
-			slotIdx := clientIdx*blobsPerClient + blobIdx
-			allCommitments[slotIdx] = blob.Commitment()
-			allPromiseHashes[slotIdx] = promiseHash
-		}
+					slotIdx := clientIdx*tt.blobsPerClient + blobIdx
+					allCommitments[slotIdx] = blob.Commitment()
+					allPromiseHashes[slotIdx] = promiseHash
+				}
 
-		return nil
-	})
-	require.NoError(t, err)
+				return nil
+			})
+			require.NoError(t, err)
 
-	// verify storage: all validators should have rows and payment promises for all uploads
-	err = env.ForEachStore(t.Context(), func(ctx context.Context, store *fibre.Store, storeIdx int) error {
-		for i, commitment := range allCommitments {
-			rows, err := store.Get(ctx, commitment)
-			if err != nil {
-				return fmt.Errorf("store %d missing rows for commitment %s: %w", storeIdx, commitment.String(), err)
-			}
+			// verify storage: all validators should have rows and payment promises for all uploads
+			err = env.ForEachStore(t.Context(), func(ctx context.Context, store *fibre.Store, storeIdx int) error {
+				for i, commitment := range allCommitments {
+					rows, err := store.Get(ctx, commitment)
+					if err != nil {
+						return fmt.Errorf("store %d missing rows for commitment %s: %w", storeIdx, commitment.String(), err)
+					}
 
-			// verify rows are not empty
-			if len(rows.Rows) == 0 {
-				return fmt.Errorf("store %d has empty rows for commitment %s", storeIdx, commitment.String())
-			}
+					// verify rows are not empty
+					if len(rows.Rows) == 0 {
+						return fmt.Errorf("store %d has empty rows for commitment %s", storeIdx, commitment.String())
+					}
 
-			// verify RLC root is set
-			if rows.GetRoot() == nil || len(rows.GetRoot()) != 32 {
-				return fmt.Errorf("store %d has invalid RLC root for commitment %s", storeIdx, commitment.String())
-			}
+					// verify RLC root is set
+					if rows.GetRoot() == nil || len(rows.GetRoot()) != 32 {
+						return fmt.Errorf("store %d has invalid RLC root for commitment %s", storeIdx, commitment.String())
+					}
 
-			// verify payment promise is stored
-			promise, err := store.GetPaymentPromise(ctx, allPromiseHashes[i])
-			if err != nil {
-				return fmt.Errorf("store %d missing payment promise for hash %x: %w", storeIdx, allPromiseHashes[i], err)
-			}
+					// verify payment promise is stored
+					promise, err := store.GetPaymentPromise(ctx, allPromiseHashes[i])
+					if err != nil {
+						return fmt.Errorf("store %d missing payment promise for hash %x: %w", storeIdx, allPromiseHashes[i], err)
+					}
 
-			// verify payment promise commitment matches
-			if !promise.Commitment.Equals(commitment) {
-				return fmt.Errorf("store %d payment promise commitment mismatch: got %s, expected %s",
-					storeIdx, promise.Commitment.String(), commitment.String())
-			}
-		}
+					// verify payment promise commitment matches
+					if !promise.Commitment.Equals(commitment) {
+						return fmt.Errorf("store %d payment promise commitment mismatch: got %s, expected %s",
+							storeIdx, promise.Commitment.String(), commitment.String())
+					}
+				}
 
-		return nil
-	})
-	require.NoError(t, err)
+				return nil
+			})
+			require.NoError(t, err)
+		})
+	}
 }

--- a/fibre/grpc/fibre_client.go
+++ b/fibre/grpc/fibre_client.go
@@ -36,7 +36,8 @@ func (f *fibreClientCloser) Close() error {
 // DefaultNewClientFn returns the default [NewClientFn] that uses the provided
 // [validator.HostRegistry] to resolve validator hosts and establishes insecure gRPC connections
 // with OpenTelemetry instrumentation for distributed tracing.
-func DefaultNewClientFn(hostReg validator.HostRegistry) NewClientFn {
+// The maxMsgSize parameter sets the maximum gRPC message size for send and receive operations.
+func DefaultNewClientFn(hostReg validator.HostRegistry, maxMsgSize int) NewClientFn {
 	return func(ctx context.Context, val *core.Validator) (Client, error) {
 		host, err := hostReg.GetHost(ctx, val)
 		if err != nil {
@@ -47,6 +48,10 @@ func DefaultNewClientFn(hostReg validator.HostRegistry) NewClientFn {
 		conn, err := grpclib.NewClient(host.String(),
 			grpclib.WithTransportCredentials(insecure.NewCredentials()),
 			grpclib.WithStatsHandler(otelgrpc.NewClientHandler()),
+			grpclib.WithDefaultCallOptions(
+				grpclib.MaxCallRecvMsgSize(maxMsgSize),
+				grpclib.MaxCallSendMsgSize(maxMsgSize),
+			),
 		)
 		if err != nil {
 			return nil, err

--- a/fibre/payment_promise.go
+++ b/fibre/payment_promise.go
@@ -123,9 +123,12 @@ func (p *PaymentPromise) Validate() error {
 		return fmt.Errorf("signer key must be %d bytes, got %d", secp256k1.PubKeySize, len(p.SignerKey.Key))
 	}
 
-	// chain ID must not be empty
+	// chain ID must not be empty and within length limit
 	if p.ChainID == "" {
 		return errors.New("chain id must not be empty")
+	}
+	if len(p.ChainID) > maxChainIDSize {
+		return fmt.Errorf("chain id length %d exceeds maximum %d", len(p.ChainID), maxChainIDSize)
 	}
 
 	// upload size must be positive
@@ -167,12 +170,23 @@ func (p *PaymentPromise) Validate() error {
 }
 
 const (
+	// MaxPaymentPromiseSize is the theoretical minimum size of all PaymentPromise fields
+	// before protobuf encoding overhead
+	MaxPaymentPromiseSize = signBytesFixedSize + signatureSize + maxChainIDSize
+
 	// signBytesPrefix is prepended to the sign bytes to ensure the resulting signed message
 	// can't be confused with a consensus message (domain separation).
 	signBytesPrefix = "fibre/pp:v0"
 	// signBytesFixedSize is the size of all the constant fixed size fields.
-	// Format: signerPubKey(33) + namespace(29) + blobSize(4) + commitment(32) + blobVersion(4) + height(8)
-	signBytesFixedSize = secp256k1.PubKeySize + share.NamespaceSize + 4 + 32 + 4 + 8
+	// Format: signerPubKey(33) + namespace(29) + blobSize(4) + commitment(32) + blobVersion(4) + height(8) + timestamp(15)
+	signBytesFixedSize = secp256k1.PubKeySize + share.NamespaceSize + 4 + 32 + 4 + 8 + 15
+
+	// maxChainIDSize is the maximum allowed chain ID length.
+	// Examples: "celestia" (8), "mocha-4" (7), "arabica-11" (10)
+	maxChainIDSize = 20
+
+	// signatureSize is the size of a secp256k1 signature in compact format (32 bytes r + 32 bytes s)
+	signatureSize = 64
 )
 
 // SignBytes returns the bytes that should be signed for this [PaymentPromise].
@@ -192,9 +206,11 @@ func (p *PaymentPromise) SignBytes() ([]byte, error) {
 			p.signBytesErr = fmt.Errorf("marshalling timestamp: %w", err)
 			return
 		}
+		// trim the last zone byte which is always UTC
+		timestampBytes = timestampBytes[:len(timestampBytes)-1]
 
 		// calculate total size including the prefix
-		totalSize := len(signBytesPrefix) + len(p.ChainID) + signBytesFixedSize + len(timestampBytes)
+		totalSize := len(signBytesPrefix) + len(p.ChainID) + signBytesFixedSize
 		buf := make([]byte, 0, totalSize)
 
 		// prepend domain separation prefix

--- a/fibre/payment_promise.go
+++ b/fibre/payment_promise.go
@@ -170,8 +170,8 @@ func (p *PaymentPromise) Validate() error {
 }
 
 const (
-	// MaxPaymentPromiseSize is the theoretical minimum size of all PaymentPromise fields
-	// before protobuf encoding overhead
+	// MaxPaymentPromiseSize is the theoretical maximum size of all PaymentPromise fields
+	// (excluding encoding overhead, like protobuf)
 	MaxPaymentPromiseSize = signBytesFixedSize + signatureSize + maxChainIDSize
 
 	// signBytesPrefix is prepended to the sign bytes to ensure the resulting signed message
@@ -206,8 +206,6 @@ func (p *PaymentPromise) SignBytes() ([]byte, error) {
 			p.signBytesErr = fmt.Errorf("marshalling timestamp: %w", err)
 			return
 		}
-		// trim the last zone byte which is always UTC
-		timestampBytes = timestampBytes[:len(timestampBytes)-1]
 
 		// calculate total size including the prefix
 		totalSize := len(signBytesPrefix) + len(p.ChainID) + signBytesFixedSize

--- a/fibre/server_upload_test.go
+++ b/fibre/server_upload_test.go
@@ -3,7 +3,6 @@ package fibre_test
 import (
 	"context"
 	"crypto/ed25519"
-	"path/filepath"
 	"testing"
 	"time"
 
@@ -151,15 +150,10 @@ func makeTestServer(t *testing.T) (*fibre.Server, validator.Set, *core.Validator
 		Height:       100,
 	}
 
-	cfg := fibre.DefaultServerConfig()
-	// Set a temporary directory for the BadgerDB store
-	tmpDir := t.TempDir()
-	cfg.Path = filepath.Join(tmpDir, "fibre-store")
-
 	// use first validator as the server's identity
 	privVal := newTestPrivValidator(privKeys[0])
 
-	// Find the server validator in the ValidatorSet by matching the address
+	// find the server validator in the ValidatorSet by matching the address
 	// Note: core.NewValidatorSet may reorder validators, so we can't assume validators[0] == privKeys[0]
 	serverPubKey, err := privVal.GetPubKey()
 	require.NoError(t, err)
@@ -174,7 +168,7 @@ func makeTestServer(t *testing.T) (*fibre.Server, validator.Set, *core.Validator
 		privVal,
 		&mockQueryClient{},
 		&mockValidatorSetGetter{set: valSet},
-		cfg,
+		fibre.DefaultServerConfig(),
 	)
 	require.NoError(t, err)
 

--- a/multiplexer/abci/multiplexer.go
+++ b/multiplexer/abci/multiplexer.go
@@ -193,6 +193,9 @@ func (m *Multiplexer) enableGRPCAndAPIServers(app servertypes.Application) error
 			if err != nil {
 				return fmt.Errorf("failed to start Fibre server: %w", err)
 			}
+			maxMsgSize := fibre.MaxMessageSize(serverConfig.BlobConfig)
+			m.svrCfg.GRPC.MaxRecvMsgSize = maxMsgSize
+			m.svrCfg.GRPC.MaxSendMsgSize = maxMsgSize
 
 			// Add graceful shutdown for Fibre server
 			if fibreServer != nil {


### PR DESCRIPTION
Make sure that both GRPC client and server configurations support sending and receiving the largest blob size. It dynamically calculates the max size based on config values, including ShardingFactor(number of validators). 

Tested with integration testing that runs real grpc client and server.

Closes #65 