### PR TITLE
refactor(fibre/validator): move `Done` out of `SignatureSet`

### DIFF
--- a/fibre/client_upload.go
+++ b/fibre/client_upload.go
@@ -171,14 +171,15 @@ func (c *Client) signedPromise(ns share.Namespace, blob *Blob, height uint64) (*
 	return promise, nil
 }
 
-// uploadTo uploads rows to a single validator and adds the response signature to the signature set.
+// uploadTo uploads shard to a single validator and adds the response signature to the signature set.
+// Returns true if enough signatures have been collected after adding this signature.
 func (c *Client) uploadTo(
 	ctx context.Context,
 	val *core.Validator,
 	req *types.UploadRowsRequest,
 	blob *Blob,
 	sigSet *validator.SignatureSet,
-) {
+) bool {
 	log := c.log.With(
 		"validator", val.Address.String(),
 		"blob_commitment", blob.Commitment(),
@@ -199,7 +200,7 @@ func (c *Client) uploadTo(
 		log.WarnContext(ctx, "can't get grpc.FibreClient", "error", err)
 		span.RecordError(err)
 		span.SetStatus(codes.Error, "can't get grpc.FibreClient")
-		return
+		return false
 	}
 	span.AddEvent("client_acquired")
 
@@ -210,7 +211,7 @@ func (c *Client) uploadTo(
 			log.WarnContext(ctx, "failed to generate proof for row", "row_index", rowPb.Index, "error", err)
 			span.RecordError(err, trace.WithAttributes(attribute.Int("row_index", int(rowPb.Index))))
 			span.SetStatus(codes.Error, "failed to generate proof for row")
-			return
+			return false
 		}
 		req.Rows.Rows[i].Data = row.Row
 		req.Rows.Rows[i].Proof = row.RowProof.RowProof
@@ -223,7 +224,7 @@ func (c *Client) uploadTo(
 		log.WarnContext(ctx, "failed to upload rows", "error", err)
 		span.RecordError(err)
 		span.SetStatus(codes.Error, "failed to upload rows")
-		return
+		return false
 	}
 	span.AddEvent("rows_uploaded")
 
@@ -233,21 +234,22 @@ func (c *Client) uploadTo(
 		log.WarnContext(ctx, "failed to parse signature", "error", err)
 		span.RecordError(err)
 		span.SetStatus(codes.Error, "failed to parse signature")
-		return
+		return false
 	}
 
-	// apply signature response
-	err = sigSet.Add(val, signature)
+	// apply signature response and check if we have enough
+	hasEnough, err := sigSet.Add(val, signature)
 	if err != nil {
 		log.WarnContext(ctx, "failed to add signature", "error", err)
 		span.RecordError(err)
 		span.SetStatus(codes.Error, "failed to add signature")
-		return
+		return false
 	}
 
 	log.DebugContext(ctx, "successfully uploaded to validator")
 	span.AddEvent("signature_verified")
 	span.SetStatus(codes.Ok, "")
+	return hasEnough
 }
 
 // uploadRows pushes rows to all validators concurrently and collects signature responses.
@@ -262,6 +264,11 @@ func (c *Client) uploadRows(
 	var (
 		responses            atomic.Uint32         // tracks finished responses
 		responsesExhaustedCh = make(chan struct{}) // closes when all responses complete
+	)
+
+	var (
+		sigsCollectedOnce atomic.Bool
+		sigsCollectedCh   = make(chan struct{}) // closes when enough signatures are collected
 	)
 
 	for val, req := range requests {
@@ -287,13 +294,16 @@ func (c *Client) uploadRows(
 				c.closeWg.Done()
 			}()
 
-			c.uploadTo(ctx, val, req, blob, sigSet)
+			isDone := c.uploadTo(ctx, val, req, blob, sigSet)
+			if isDone && sigsCollectedOnce.CompareAndSwap(false, true) {
+				close(sigsCollectedCh)
+			}
 		}(val, req)
 	}
 
 	select {
 	case <-responsesExhaustedCh: // no more responses to wait for
-	case <-sigSet.Done(): // enough signatures collected
+	case <-sigsCollectedCh: // enough signatures collected
 	case <-ctx.Done():
 		return ctx.Err()
 	}

--- a/fibre/validator/signature_set.go
+++ b/fibre/validator/signature_set.go
@@ -19,7 +19,6 @@ type SignatureSet struct {
 	mu          sync.Mutex
 	votingPower int64
 	signatures  [][]byte
-	done        chan struct{}
 }
 
 // NewSignatureSet creates a new [SignatureSet] for collecting and validating signatures.
@@ -32,17 +31,17 @@ func (s Set) NewSignatureSet(targetVotingPower, targetValidatorsCount cmtmath.Fr
 		minRequiredVotingPower: minRequiredVotingPower,
 		minRequiredSignatures:  minRequiredSignatures,
 		signatures:             make([][]byte, 0, s.Size()),
-		done:                   make(chan struct{}),
 	}
 }
 
 // Add validates and adds a signature from the given validator.
 // Returns an error if the signature is invalid.
-func (ss *SignatureSet) Add(val *core.Validator, signature []byte) error {
+// Returns true if enough signatures have been collected to meet both thresholds.
+func (ss *SignatureSet) Add(val *core.Validator, signature []byte) (bool, error) {
 	// verify signature
 	pubKey := val.PubKey.Bytes()
 	if !ed25519.Verify(ed25519.PublicKey(pubKey), ss.requiredBytesSigned, signature) {
-		return fmt.Errorf("invalid signature from validator %s", val.Address.String())
+		return false, fmt.Errorf("invalid signature from validator %s", val.Address.String())
 	}
 
 	ss.mu.Lock()
@@ -52,22 +51,8 @@ func (ss *SignatureSet) Add(val *core.Validator, signature []byte) error {
 	ss.votingPower += val.VotingPower
 	ss.signatures = append(ss.signatures, signature)
 
-	// check if thresholds are met and close done channel
-	if len(ss.signatures) >= ss.minRequiredSignatures && ss.votingPower >= ss.minRequiredVotingPower {
-		select {
-		case <-ss.done:
-			// already closed
-		default:
-			close(ss.done)
-		}
-	}
-
-	return nil
-}
-
-// Done returns a channel that is closed when enough signatures are collected to meet both thresholds.
-func (ss *SignatureSet) Done() <-chan struct{} {
-	return ss.done
+	// check if thresholds are met
+	return len(ss.signatures) >= ss.minRequiredSignatures && ss.votingPower >= ss.minRequiredVotingPower, nil
 }
 
 // Signatures returns all collected signatures if thresholds are met.

--- a/fibre/validator/signature_set_test.go
+++ b/fibre/validator/signature_set_test.go
@@ -62,14 +62,9 @@ func TestSignatureSet(t *testing.T) {
 		for i := range 3 {
 			signature, err := s.privKeys[i].Sign(s.signBytes)
 			require.NoError(t, err)
-			require.NoError(t, s.sigSet.Add(s.validators[i], signature))
-		}
-
-		// Check that Done() is NOT closed when thresholds are not met
-		select {
-		case <-s.sigSet.Done():
-			t.Fatal("Done() should not be closed when thresholds are not met")
-		default:
+			hasEnough, err := s.sigSet.Add(s.validators[i], signature)
+			require.NoError(t, err)
+			require.False(t, hasEnough)
 		}
 
 		sigs, err := s.sigSet.Signatures()
@@ -92,14 +87,9 @@ func TestSignatureSet(t *testing.T) {
 		for i := range 2 {
 			signature, err := s.privKeys[i].Sign(s.signBytes)
 			require.NoError(t, err)
-			require.NoError(t, s.sigSet.Add(s.validators[i], signature))
-		}
-
-		// Check that Done() is NOT closed when thresholds are not met
-		select {
-		case <-s.sigSet.Done():
-			t.Fatal("Done() should not be closed when thresholds are not met")
-		default:
+			hasEnough, err := s.sigSet.Add(s.validators[i], signature)
+			require.NoError(t, err)
+			require.False(t, hasEnough)
 		}
 
 		sigs, err := s.sigSet.Signatures()
@@ -122,14 +112,8 @@ func TestSignatureSet(t *testing.T) {
 		for i := range 4 {
 			signature, err := s.privKeys[i].Sign(s.signBytes)
 			require.NoError(t, err)
-			require.NoError(t, s.sigSet.Add(s.validators[i], signature))
-		}
-
-		// Check that Done() is closed
-		select {
-		case <-s.sigSet.Done():
-		default:
-			t.Fatal("Done() should be closed when thresholds are met")
+			_, err = s.sigSet.Add(s.validators[i], signature)
+			require.NoError(t, err)
 		}
 
 		sigs, err := s.sigSet.Signatures()
@@ -147,17 +131,11 @@ func TestSignatureSet(t *testing.T) {
 				defer wg.Done()
 				signature, err := s.privKeys[idx].Sign(s.signBytes)
 				require.NoError(t, err)
-				require.NoError(t, s.sigSet.Add(s.validators[idx], signature))
+				_, err = s.sigSet.Add(s.validators[idx], signature)
+				require.NoError(t, err)
 			}(i)
 		}
 		wg.Wait()
-
-		// Check that Done() is closed
-		select {
-		case <-s.sigSet.Done():
-		default:
-			t.Fatal("Done() should be closed when thresholds are met")
-		}
 
 		sigs, err := s.sigSet.Signatures()
 		require.NoError(t, err)
@@ -171,9 +149,10 @@ func TestSignatureSet(t *testing.T) {
 		signature, err := s.privKeys[0].Sign(wrongSignBytes)
 		require.NoError(t, err)
 
-		err = s.sigSet.Add(s.validators[0], signature)
+		hasEnough, err := s.sigSet.Add(s.validators[0], signature)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "invalid signature")
+		require.False(t, hasEnough)
 	})
 
 	t.Run("MixedMissAndValid", func(t *testing.T) {
@@ -183,14 +162,8 @@ func TestSignatureSet(t *testing.T) {
 		for i := range 3 {
 			signature, err := s.privKeys[i].Sign(s.signBytes)
 			require.NoError(t, err)
-			require.NoError(t, s.sigSet.Add(s.validators[i], signature))
-		}
-
-		// Check that Done() is closed
-		select {
-		case <-s.sigSet.Done():
-		default:
-			t.Fatal("Done() should be closed when thresholds are met")
+			_, err = s.sigSet.Add(s.validators[i], signature)
+			require.NoError(t, err)
 		}
 
 		sigs, err := s.sigSet.Signatures()

--- a/x/fibre/keeper/msg_server.go
+++ b/x/fibre/keeper/msg_server.go
@@ -347,8 +347,12 @@ func (ms msgServer) validateValidatorSignatures(ctx sdk.Context, signBytes []byt
 		}
 
 		// Add signature to set (this validates the signature internally)
-		if err := sigSet.Add(cmtValidators[i], signature); err != nil {
+		hasEnough, err := sigSet.Add(cmtValidators[i], signature)
+		if err != nil {
 			return errorsmod.Wrapf(sdkerrors.ErrInvalidRequest, "invalid signature at index %d: %s", i, err)
+		}
+		if hasEnough {
+			return nil
 		}
 	}
 


### PR DESCRIPTION
Pure refactor that removes done channel and logic around closing it from `SignatureSet` to a more appropriate place, which is`uploadRows` method, encapsulating all the validator concurrency logic in a single place.

No functional changes expected.
Very low priority pr to review