### PR TITLE
chore(fibre): server upload test without grpc

### DIFF
--- a/fibre/client_server_test.go
+++ b/fibre/client_server_test.go
@@ -136,7 +136,7 @@ func makeTestServers(
 		serverCfg := fibre.DefaultServerConfig()
 		// Set a temporary directory for the BadgerDB store
 		tmpDir := t.TempDir()
-		serverCfg.StoreConfig.Path = filepath.Join(tmpDir, "fibre-store")
+		serverCfg.Path = filepath.Join(tmpDir, "fibre-store")
 		// create logger with unique server identifier
 		serverCfg.Log = slog.Default().With(
 			"server_idx", i,
@@ -157,7 +157,7 @@ func makeTestServers(
 		types.RegisterQueryServer(grpcServer, mockQueryServer)
 
 		// Register mock BlockAPI service
-		valSetProto, err := valSet.ValidatorSet.ToProto()
+		valSetProto, err := valSet.ToProto()
 		require.NoError(t, err)
 		mockBlockAPIServer := &mockBlockAPIServer{
 			validatorSetResponse: &coregrpc.ValidatorSetResponse{

--- a/fibre/server.go
+++ b/fibre/server.go
@@ -62,44 +62,27 @@ type Server struct {
 	tracer trace.Tracer
 }
 
-// NewServer creates a new Fibre [Server] with the provided dependencies.
-// Returns an error if the validator's public key cannot be retrieved.
+// NewServer creates a new Fibre [Server] with default Badger store backend.
+// Returns an error if the validator's public key cannot be retrieved or
+// if Badger instance cannot be started.
 func NewServer(
 	privVal core.PrivValidator,
 	queryClient types.QueryClient,
 	valGet validator.SetGetter,
 	cfg ServerConfig,
 ) (*Server, error) {
-	if cfg.Log == nil {
-		cfg.Log = slog.Default().WithGroup("fibre-server")
-	}
-	if cfg.Tracer == nil {
-		cfg.Tracer = otel.Tracer("fibre-server")
-	}
-
-	// cache the validator's public key in case the implementation does IO internally
-	pubKey, err := privVal.GetPubKey()
-	if err != nil {
-		return nil, fmt.Errorf("getting validator public key: %w", err)
-	}
-
 	store, err := NewBadgerStore(cfg.StoreConfig)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create Fibre store: %w", err)
 	}
 
-	server := &Server{
-		cfg:         cfg,
-		privVal:     privVal,
-		pubKey:      pubKey,
-		queryClient: queryClient,
-		valGet:      valGet,
-		store:       store,
-		log:         cfg.Log,
-		tracer:      cfg.Tracer,
-	}
-
-	return server, nil
+	return newServer(
+		privVal,
+		queryClient,
+		valGet,
+		store,
+		cfg,
+	)
 }
 
 // NewServerFromGRPC creates a new Fibre [Server] from a gRPC server and client.
@@ -118,6 +101,57 @@ func NewServerFromGRPC(
 		return nil, err
 	}
 	types.RegisterFibreServer(grpcServer, server)
+	return server, nil
+}
+
+// NewInMemoryServer creates a new Fibre [Server] with an in-memory store backend.
+func NewInMemoryServer(
+	privVal core.PrivValidator,
+	queryClient types.QueryClient,
+	valGet validator.SetGetter,
+	cfg ServerConfig,
+) (*Server, error) {
+	memStore := NewMemoryStore(cfg.StoreConfig)
+	return newServer(
+		privVal,
+		queryClient,
+		valGet,
+		memStore,
+		cfg,
+	)
+}
+
+func newServer(
+	privVal core.PrivValidator,
+	queryClient types.QueryClient,
+	valGet validator.SetGetter,
+	store *Store,
+	cfg ServerConfig,
+) (*Server, error) {
+	if cfg.Log == nil {
+		cfg.Log = slog.Default().WithGroup("fibre-server")
+	}
+	if cfg.Tracer == nil {
+		cfg.Tracer = otel.Tracer("fibre-server")
+	}
+
+	// cache the validator's public key in case the implementation does IO internally
+	pubKey, err := privVal.GetPubKey()
+	if err != nil {
+		return nil, fmt.Errorf("getting validator public key: %w", err)
+	}
+
+	server := &Server{
+		cfg:         cfg,
+		privVal:     privVal,
+		pubKey:      pubKey,
+		queryClient: queryClient,
+		valGet:      valGet,
+		store:       store,
+		log:         cfg.Log,
+		tracer:      cfg.Tracer,
+	}
+
 	return server, nil
 }
 

--- a/fibre/server_upload_test.go
+++ b/fibre/server_upload_test.go
@@ -1,8 +1,8 @@
 package fibre_test
 
 import (
+	"context"
 	"crypto/ed25519"
-	"net"
 	"path/filepath"
 	"testing"
 	"time"
@@ -15,13 +15,11 @@ import (
 	"github.com/celestiaorg/rsema1d/field"
 	"github.com/cometbft/cometbft/crypto"
 	cmtproto "github.com/cometbft/cometbft/proto/tendermint/types"
-	coregrpc "github.com/cometbft/cometbft/rpc/grpc"
 	core "github.com/cometbft/cometbft/types"
 	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
 	txsigning "github.com/cosmos/cosmos-sdk/types/tx/signing"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
 )
 
 // TestServerUploadRows unit tests the [Server.UploadRows].
@@ -156,7 +154,7 @@ func makeTestServer(t *testing.T) (*fibre.Server, validator.Set, *core.Validator
 	cfg := fibre.DefaultServerConfig()
 	// Set a temporary directory for the BadgerDB store
 	tmpDir := t.TempDir()
-	cfg.StoreConfig.Path = filepath.Join(tmpDir, "fibre-store")
+	cfg.Path = filepath.Join(tmpDir, "fibre-store")
 
 	// use first validator as the server's identity
 	privVal := newTestPrivValidator(privKeys[0])
@@ -171,45 +169,14 @@ func makeTestServer(t *testing.T) (*fibre.Server, validator.Set, *core.Validator
 	require.True(t, found, "server validator not found in validator set")
 	require.NotNil(t, serverValidator, "server validator is nil")
 
-	// Create gRPC server with mock services
-	grpcServer := grpc.NewServer()
-
-	// Register mock Query service
-	mockQueryServer := &mockQueryServer{}
-	types.RegisterQueryServer(grpcServer, mockQueryServer)
-
-	// Register mock BlockAPI service
-	valSetProto, err := valSet.ValidatorSet.ToProto()
-	require.NoError(t, err)
-	mockBlockAPIServer := &mockBlockAPIServer{
-		validatorSetResponse: &coregrpc.ValidatorSetResponse{
-			ValidatorSet: valSetProto,
-			Height:       int64(valSet.Height),
-		},
-	}
-	coregrpc.RegisterBlockAPIServer(grpcServer, mockBlockAPIServer)
-
-	// Create in-memory listener
-	listener, err := net.Listen("tcp", "127.0.0.1:0")
-	require.NoError(t, err)
-
-	// Create client connection to the mock server (will connect after server starts)
-	conn, err := grpc.NewClient(
-		listener.Addr().String(),
-		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	// create server
+	server, err := fibre.NewInMemoryServer(
+		privVal,
+		&mockQueryClient{},
+		&mockValidatorSetGetter{set: valSet},
+		cfg,
 	)
 	require.NoError(t, err)
-
-	// Create server with gRPC infrastructure - this registers the Fibre service
-	server, err := fibre.NewServerFromGRPC(privVal, grpcServer, conn, cfg)
-	require.NoError(t, err)
-
-	// Start gRPC server after all services are registered
-	go func() {
-		if err := grpcServer.Serve(listener); err != nil {
-			t.Logf("gRPC server error: %v", err)
-		}
-	}()
 
 	return server, valSet, serverValidator
 }
@@ -309,6 +276,30 @@ func makeTestRequest(
 	}
 
 	return req
+}
+
+// mockQueryClient is a mock implementation of types.QueryClient for testing.
+type mockQueryClient struct{}
+
+func (m *mockQueryClient) Params(ctx context.Context, in *types.QueryParamsRequest, opts ...grpc.CallOption) (*types.QueryParamsResponse, error) {
+	return &types.QueryParamsResponse{}, nil
+}
+
+func (m *mockQueryClient) EscrowAccount(ctx context.Context, in *types.QueryEscrowAccountRequest, opts ...grpc.CallOption) (*types.QueryEscrowAccountResponse, error) {
+	return &types.QueryEscrowAccountResponse{}, nil
+}
+
+func (m *mockQueryClient) Withdrawals(ctx context.Context, in *types.QueryWithdrawalsRequest, opts ...grpc.CallOption) (*types.QueryWithdrawalsResponse, error) {
+	return &types.QueryWithdrawalsResponse{}, nil
+}
+
+func (m *mockQueryClient) IsPaymentProcessed(ctx context.Context, in *types.QueryIsPaymentProcessedRequest, opts ...grpc.CallOption) (*types.QueryIsPaymentProcessedResponse, error) {
+	return &types.QueryIsPaymentProcessedResponse{}, nil
+}
+
+func (m *mockQueryClient) ValidatePaymentPromise(ctx context.Context, in *types.QueryValidatePaymentPromiseRequest, opts ...grpc.CallOption) (*types.QueryValidatePaymentPromiseResponse, error) {
+	// Always return valid for testing
+	return &types.QueryValidatePaymentPromiseResponse{IsValid: true}, nil
 }
 
 // testPrivValidator is a simple mock PrivValidator for testing.


### PR DESCRIPTION
This is a minor post #59 test cleanup:
* keeping server upload pure unit tests without running grpc server as it was
* minor golangci-lint issues