### PR TITLE
fix(fibre/grpc): single-flight protection workaround

### DIFF
--- a/fibre/grpc/host_registry.go
+++ b/fibre/grpc/host_registry.go
@@ -29,6 +29,12 @@ func NewHostRegistry(queryClient types.QueryClient) *HostRegistry {
 	}
 }
 
+// Start the host registry by pulling all active fibre providers.
+func (g *HostRegistry) Start(ctx context.Context) error {
+	return g.PullAll(ctx)
+}
+
+// GetHost implements the HostRegistry interface.
 func (g *HostRegistry) GetHost(ctx context.Context, val *core.Validator) (validator.Host, error) {
 	host, err := g.getHost(ctx, val)
 	if err != nil {
@@ -50,18 +56,6 @@ func (g *HostRegistry) getHost(ctx context.Context, val *core.Validator) (valida
 	// check the cache first
 	if host, ok := g.readHost(valConAddr); ok {
 		return host, nil
-	}
-
-	// if the cache is empty, fetch all active fibre providers
-	if g.cacheLen() == 0 {
-		if err := g.PullAll(ctx); err != nil {
-			return "", err
-		}
-		if host, ok := g.readHost(valConAddr); ok {
-			return host, nil
-		} else {
-			return "", fmt.Errorf("host not found for validator %s", valConAddr)
-		}
 	}
 
 	// look up the specific validator's host if it's missing from the cache. It might have
@@ -116,11 +110,4 @@ func (g *HostRegistry) writeHost(key string, host validator.Host) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
 	g.cachedHosts[key] = host
-}
-
-// cacheLen returns the length of the cache with a read lock.
-func (g *HostRegistry) cacheLen() int {
-	g.mu.RLock()
-	defer g.mu.RUnlock()
-	return len(g.cachedHosts)
 }

--- a/fibre/grpc/host_registry_e2e_test.go
+++ b/fibre/grpc/host_registry_e2e_test.go
@@ -44,9 +44,11 @@ func (s *IntegrationTestSuite) SetupSuite() {
 	s.ecfg = encoding.MakeConfig(app.ModuleEncodingRegisters...)
 
 	s.hostRegistry = grpc.NewHostRegistry(types.NewQueryClient(s.cctx.GRPCClient))
+	err := s.hostRegistry.Start(t.Context())
+	require.NoError(t, err)
 
 	// Wait for at least one block to be produced before querying
-	_, err := s.cctx.WaitForHeight(1)
+	_, err = s.cctx.WaitForHeight(1)
 	require.NoError(t, err, "failed to wait for first block")
 
 	// Use the GRPCClient to setup a cmtservice query client and query the validator set

--- a/fibre/grpc/host_registry_test.go
+++ b/fibre/grpc/host_registry_test.go
@@ -61,28 +61,15 @@ func TestGetHost(t *testing.T) {
 	tests := []struct {
 		name     string
 		mock     *mockQueryClient
-		preCache func(*grpc.HostRegistry)
+		preCache bool
 		want     string
 		wantErr  string
 	}{
 		{
-			name: "empty cache success",
-			mock: &mockQueryClient{
-				allFibreProvidersFn: func(context.Context, *types.QueryAllFibreProvidersRequest, ...grpc2.CallOption) (*types.QueryAllFibreProvidersResponse, error) {
-					return &types.QueryAllFibreProvidersResponse{
-						Providers: []types.FibreProvider{{ValidatorConsensusAddress: consAddr, Info: types.FibreProviderInfo{Host: expectedHost}}},
-					}, nil
-				},
-			},
-			want: expectedHost,
-		},
-		{
 			name: "empty cache not found",
 			mock: &mockQueryClient{
-				allFibreProvidersFn: func(context.Context, *types.QueryAllFibreProvidersRequest, ...grpc2.CallOption) (*types.QueryAllFibreProvidersResponse, error) {
-					return &types.QueryAllFibreProvidersResponse{
-						Providers: []types.FibreProvider{{ValidatorConsensusAddress: "other", Info: types.FibreProviderInfo{Host: "other.com"}}},
-					}, nil
+				fibreProviderInfoFn: func(context.Context, *types.QueryFibreProviderInfoRequest, ...grpc2.CallOption) (*types.QueryFibreProviderInfoResponse, error) {
+					return &types.QueryFibreProviderInfoResponse{Info: &types.FibreProviderInfo{Host: "other.com"}, Found: false}, nil
 				},
 			},
 			wantErr: "host not found",
@@ -90,7 +77,7 @@ func TestGetHost(t *testing.T) {
 		{
 			name: "network error",
 			mock: &mockQueryClient{
-				allFibreProvidersFn: func(context.Context, *types.QueryAllFibreProvidersRequest, ...grpc2.CallOption) (*types.QueryAllFibreProvidersResponse, error) {
+				fibreProviderInfoFn: func(context.Context, *types.QueryFibreProviderInfoRequest, ...grpc2.CallOption) (*types.QueryFibreProviderInfoResponse, error) {
 					return nil, errors.New("network error")
 				},
 			},
@@ -105,7 +92,7 @@ func TestGetHost(t *testing.T) {
 					}, nil
 				},
 			},
-			preCache: func(registry *grpc.HostRegistry) { _ = registry.PullAll(context.Background()) },
+			preCache: true,
 			want:     expectedHost,
 		},
 		{
@@ -120,7 +107,7 @@ func TestGetHost(t *testing.T) {
 					return &types.QueryFibreProviderInfoResponse{Info: &types.FibreProviderInfo{Host: expectedHost}, Found: true}, nil
 				},
 			},
-			preCache: func(registry *grpc.HostRegistry) { _ = registry.PullAll(context.Background()) },
+			preCache: true,
 			want:     expectedHost,
 		},
 		{
@@ -135,16 +122,14 @@ func TestGetHost(t *testing.T) {
 					return &types.QueryFibreProviderInfoResponse{Found: false}, nil
 				},
 			},
-			preCache: func(registry *grpc.HostRegistry) { _ = registry.PullAll(context.Background()) },
+			preCache: true,
 			wantErr:  "host not found",
 		},
 		{
 			name: "invalid URL",
 			mock: &mockQueryClient{
-				allFibreProvidersFn: func(context.Context, *types.QueryAllFibreProvidersRequest, ...grpc2.CallOption) (*types.QueryAllFibreProvidersResponse, error) {
-					return &types.QueryAllFibreProvidersResponse{
-						Providers: []types.FibreProvider{{ValidatorConsensusAddress: consAddr, Info: types.FibreProviderInfo{Host: "ht!tp://bad"}}},
-					}, nil
+				fibreProviderInfoFn: func(context.Context, *types.QueryFibreProviderInfoRequest, ...grpc2.CallOption) (*types.QueryFibreProviderInfoResponse, error) {
+					return &types.QueryFibreProviderInfoResponse{Found: true, Info: &types.FibreProviderInfo{Host: "ht!tp://bad"}}, nil
 				},
 			},
 			wantErr: "invalid host",
@@ -154,10 +139,11 @@ func TestGetHost(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			registry := grpc.NewHostRegistry(tt.mock)
-			if tt.preCache != nil {
-				tt.preCache(registry)
+			if tt.preCache {
+				err := registry.Start(context.Background())
+				require.NoError(t, err)
 			}
-			host, err := registry.GetHost(context.Background(), val)
+			host, err := registry.GetHost(t.Context(), val)
 			if tt.wantErr != "" {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.wantErr)
@@ -203,12 +189,12 @@ func TestPullAll(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			registry := grpc.NewHostRegistry(tt.mock)
-			err := registry.PullAll(context.Background())
+			err := registry.PullAll(t.Context())
 			if tt.wantErr {
 				require.Error(t, err)
 			} else {
 				require.NoError(t, err)
-				host, _ := registry.GetHost(context.Background(), val)
+				host, _ := registry.GetHost(t.Context(), val)
 				assert.Equal(t, expectedHost, host.String())
 			}
 		})
@@ -284,6 +270,8 @@ func TestPullHost_OverwritesCache(t *testing.T) {
 			return &types.QueryFibreProviderInfoResponse{Info: &types.FibreProviderInfo{Host: secondHost}, Found: true}, nil
 		},
 	})
+	err := registry.Start(t.Context())
+	require.NoError(t, err)
 
 	host, _ := registry.GetHost(context.Background(), val)
 	assert.Equal(t, firstHost, host.String())
@@ -312,13 +300,15 @@ func TestHostRegistry_ConcurrentAccess(t *testing.T) {
 			}, nil
 		},
 	})
+	err := registry.Start(t.Context())
+	require.NoError(t, err)
 
 	var wg sync.WaitGroup
 	for i := 0; i < 100; i++ {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			host, err := registry.GetHost(context.Background(), val)
+			host, err := registry.GetHost(t.Context(), val)
 			require.NoError(t, err)
 			assert.Equal(t, expectedHost, host.String())
 		}()
@@ -348,6 +338,8 @@ func TestGetHost_MultipleValidators(t *testing.T) {
 			return &types.QueryAllFibreProvidersResponse{Providers: providers}, nil
 		},
 	})
+	err := registry.Start(t.Context())
+	require.NoError(t, err)
 
 	for i, val := range vals {
 		host, _ := registry.GetHost(context.Background(), val)


### PR DESCRIPTION
This is a flup from accidentally merged #52. The problem there was that `GetHost` lazily fetched all the providers, and because there was no single-flight protection, this results in 100 requests. Instead of implementing singleflight protection, the solution is to simply avoid the last fetch of the full initial set of validators. The lazy fetch still stays for granular host, but the full pull is now part of the `Start` method. This is also nice because the latency of fetching the hosts will be excluded from measurements.