### PR TITLE
fix(fibre/client): cancel context per validator upload

### DIFF
--- a/fibre/client_upload.go
+++ b/fibre/client_upload.go
@@ -188,6 +188,9 @@ func (c *Client) uploadTo(
 	blob *Blob,
 	sigSet *validator.SignatureSet,
 ) bool {
+	ctx, cancel := context.WithCancel(ctx) // GRPC calls require context cancelling upon completion
+	defer cancel()
+
 	log := c.log.With(
 		"validator", val.Address.String(),
 		"blob_commitment", blob.Commitment(),


### PR DESCRIPTION
[Any grpc example](https://github.com/grpc/grpc-go/tree/master/examples) has context canceling. In fact, not canceling the context leaks memory as shown in the fibremaxxxing branch while benchmarking, thus the fix.

As opposed to canceling the global `Upload` context, this cancels the per-validator upload context, ensuring uploads continue to remaining validators in the case of an early return (2/3 sigs collected).