### PR TITLE
feat(fibre/server): time-based pruning

### DIFF
--- a/cmd/celestia-appd/cmd/start_command_standalone.go
+++ b/cmd/celestia-appd/cmd/start_command_standalone.go
@@ -109,6 +109,8 @@ func startCommandHandler(
 		if err != nil {
 			return fmt.Errorf("failed to start Fibre server: %w", err)
 		}
+		fibreServer.Start()
+
 		maxMsgSize := fibre.MaxMessageSize(serverConfig.BlobConfig)
 		svrCfg.GRPC.MaxRecvMsgSize = maxMsgSize
 		svrCfg.GRPC.MaxSendMsgSize = maxMsgSize

--- a/fibre/blob.go
+++ b/fibre/blob.go
@@ -33,6 +33,19 @@ func (c Commitment) String() string {
 	return hex.EncodeToString(c[:])
 }
 
+// CommitmentFromString decodes a [Commitment] from a hex-encoded string.
+func CommitmentFromString(s string) (Commitment, error) {
+	data, err := hex.DecodeString(s)
+	if err != nil {
+		return Commitment{}, fmt.Errorf("decoding hex: %w", err)
+	}
+	var c Commitment
+	if err := c.UnmarshalBinary(data); err != nil {
+		return Commitment{}, err
+	}
+	return c, nil
+}
+
 // Equals returns true if the two commitments are equal.
 func (c Commitment) Equals(other Commitment) bool {
 	return c == other

--- a/fibre/server.go
+++ b/fibre/server.go
@@ -1,6 +1,7 @@
 package fibre
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 	"time"
@@ -60,6 +61,8 @@ type Server struct {
 
 	log    *slog.Logger
 	tracer trace.Tracer
+
+	cancel context.CancelFunc
 }
 
 // NewServer creates a new Fibre [Server] with default Badger store backend.
@@ -164,8 +167,19 @@ func (s *Server) Store() *Store {
 	return s.store
 }
 
-// Stop stops the server.
+// Start starts background routines for the server.
+// It should be called after the server is created. Use [Stop] to stop the background routines.
+func (s *Server) Start() {
+	ctx, cancel := context.WithCancel(context.Background())
+	s.cancel = cancel
+	go s.startPruneLoop(ctx)
+}
+
+// Stop stops the server and its background routines.
 // NOTE: It is not a graceful shutdown as it doesn't await for pending requests to complete.
 func (s *Server) Stop() error {
+	if s.cancel != nil {
+		s.cancel()
+	}
 	return s.store.Close()
 }

--- a/fibre/server_prune.go
+++ b/fibre/server_prune.go
@@ -1,0 +1,40 @@
+package fibre
+
+import (
+	"context"
+	"time"
+)
+
+const pruneInterval = time.Minute
+
+// startPruneLoop starts a background goroutine that periodically prunes expired entries from the store.
+// It runs every minute and removes entries with pruneAt times before the current time.
+// The loop stops when the context is cancelled.
+func (s *Server) startPruneLoop(ctx context.Context) {
+	ticker := time.NewTicker(pruneInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			s.prune(ctx)
+		}
+	}
+}
+
+func (s *Server) prune(ctx context.Context) {
+	start := time.Now()
+	pruned, err := s.store.PruneBefore(ctx, start)
+	elapsed := time.Since(start)
+
+	if err != nil {
+		s.log.ErrorContext(ctx, "failed to prune store", "error", err, "elapsed (ms)", elapsed.Milliseconds())
+		return
+	}
+
+	if pruned > 0 {
+		s.log.InfoContext(ctx, "pruned expired entries", "pruned", pruned, "elapsed (ms)", elapsed.Milliseconds())
+	}
+}

--- a/fibre/server_upload.go
+++ b/fibre/server_upload.go
@@ -23,7 +23,7 @@ func (s *Server) UploadShard(ctx context.Context, req *types.UploadShardRequest)
 	ctx, span := s.tracer.Start(ctx, "fibre.Server.UploadShard")
 	defer span.End()
 
-	promise, promiseHash, err := s.verifyPromise(ctx, req.Promise)
+	promise, promiseHash, pruneAt, err := s.verifyPromise(ctx, req.Promise)
 	if err != nil {
 		s.log.WarnContext(ctx, "payment promise verification failed", "error", err)
 		span.RecordError(err)
@@ -33,7 +33,7 @@ func (s *Server) UploadShard(ctx context.Context, req *types.UploadShardRequest)
 
 	log := s.log.With("blob_commitment", promise.Commitment.String(), "promise_height", promise.Height)
 
-	span.AddEvent("promise_validated", trace.WithAttributes(
+	span.AddEvent("promise_verified", trace.WithAttributes(
 		attribute.String("promise_hash", hex.EncodeToString(promiseHash)),
 		attribute.String("blob_commitment", promise.Commitment.String()),
 		attribute.Int64("promise_height", int64(promise.Height)),
@@ -63,7 +63,7 @@ func (s *Server) UploadShard(ctx context.Context, req *types.UploadShardRequest)
 	))
 
 	// store payment promise and shard with RLC roots
-	if err := s.store.Put(ctx, promise, req.Shard); err != nil {
+	if err := s.store.Put(ctx, promise, req.Shard, pruneAt); err != nil {
 		log.ErrorContext(ctx, "failed to store upload data", "error", err)
 		span.RecordError(err)
 		span.SetStatus(codes.Error, "failed to store upload data")
@@ -95,41 +95,46 @@ func (s *Server) UploadShard(ctx context.Context, req *types.UploadShardRequest)
 
 // verifyPromise verifies given proto of [PaymentPromise] and returns unmarshaled form with its hash.
 // It does both stateless and stateful verification.
-func (s *Server) verifyPromise(ctx context.Context, promisePb *types.PaymentPromise) (*PaymentPromise, []byte, error) {
+// Returns the pruneAt time for the shard based on the data retention duration.
+func (s *Server) verifyPromise(ctx context.Context, promisePb *types.PaymentPromise) (*PaymentPromise, []byte, time.Time, error) {
 	promise := &PaymentPromise{}
 	if err := promise.FromProto(promisePb); err != nil {
-		return nil, nil, fmt.Errorf("invalid payment promise proto: %w", err)
+		return nil, nil, time.Time{}, fmt.Errorf("invalid payment promise proto: %w", err)
 	}
 
 	// validate PP fields matches the config
 	if promise.ChainID != s.cfg.ChainID {
-		return nil, nil, fmt.Errorf("payment promise chain ID mismatch: expected %s, got %s", s.cfg.ChainID, promise.ChainID)
+		return nil, nil, time.Time{}, fmt.Errorf("payment promise chain ID mismatch: expected %s, got %s", s.cfg.ChainID, promise.ChainID)
 	}
 	if promise.BlobVersion != uint32(s.cfg.BlobVersion) {
-		return nil, nil, fmt.Errorf("blob version mismatch: expected %d, got %d", s.cfg.BlobVersion, promise.BlobVersion)
+		return nil, nil, time.Time{}, fmt.Errorf("blob version mismatch: expected %d, got %d", s.cfg.BlobVersion, promise.BlobVersion)
 	}
-	oldestAllowed := time.Now().UTC().Add(-s.cfg.PaymentPromiseTimeout)
-	if promise.CreationTimestamp.Before(oldestAllowed) {
-		return nil, nil, fmt.Errorf("payment promise expired: %s is before %s (timeout: %s)",
-			promise.CreationTimestamp.Format(time.RFC3339),
-			oldestAllowed.Format(time.RFC3339),
-			s.cfg.PaymentPromiseTimeout)
+
+	{ //TODO(@Wondertan): to be moved to stateful verification
+		oldestAllowed := time.Now().UTC().Add(-s.cfg.PaymentPromiseTimeout)
+		if promise.CreationTimestamp.Before(oldestAllowed) {
+			return nil, nil, time.Time{}, fmt.Errorf("payment promise expired: %s is before %s (timeout: %s)",
+				promise.CreationTimestamp.Format(time.RFC3339),
+				oldestAllowed.Format(time.RFC3339),
+				s.cfg.PaymentPromiseTimeout)
+		}
+		// use height of the latest valset to verify height in the promise
+		currentValSet, err := s.valGet.Head(ctx)
+		if err != nil {
+			return nil, nil, time.Time{}, fmt.Errorf("getting current validator set: %w", err)
+		}
+		// calculate max height drift based on promise timeout and block time
+		maxHeightDrift := uint64(s.cfg.PaymentPromiseTimeout / s.cfg.BlockTime)
+		if currentValSet.Height > maxHeightDrift && promise.Height < currentValSet.Height-maxHeightDrift {
+			return nil, nil, time.Time{}, fmt.Errorf("payment promise height too far in past: %d is before min allowed %d (current: %d, timeout: %s, block time: %s)",
+				promise.Height, currentValSet.Height-maxHeightDrift, currentValSet.Height, s.cfg.PaymentPromiseTimeout, s.cfg.BlockTime)
+		}
 	}
-	// use height of the latest valset to verify height in the promise
-	currentValSet, err := s.valGet.Head(ctx)
-	if err != nil {
-		return nil, nil, fmt.Errorf("getting current validator set: %w", err)
-	}
-	// calculate max height drift based on promise timeout and block time
-	maxHeightDrift := uint64(s.cfg.PaymentPromiseTimeout / s.cfg.BlockTime)
-	if currentValSet.Height > maxHeightDrift && promise.Height < currentValSet.Height-maxHeightDrift {
-		return nil, nil, fmt.Errorf("payment promise height too far in past: %d is before min allowed %d (current: %d, timeout: %s, block time: %s)",
-			promise.Height, currentValSet.Height-maxHeightDrift, currentValSet.Height, s.cfg.PaymentPromiseTimeout, s.cfg.BlockTime)
-	}
+	pruneAt := time.Now().Add(s.cfg.DataRetentionDuration)
 
 	// stateless validation
 	if err := promise.Validate(); err != nil {
-		return nil, nil, fmt.Errorf("payment promise validation failed: %w", err)
+		return nil, nil, time.Time{}, fmt.Errorf("payment promise validation failed: %w", err)
 	}
 
 	// validate stateful constraints
@@ -137,17 +142,18 @@ func (s *Server) verifyPromise(ctx context.Context, promisePb *types.PaymentProm
 		Promise: *promisePb,
 	})
 	if err != nil {
-		return nil, nil, fmt.Errorf("stateful validation request: %w", err)
+		return nil, nil, time.Time{}, fmt.Errorf("stateful validation request: %w", err)
 	}
 	if !resp.IsValid {
-		return nil, nil, fmt.Errorf("payment promise is invalid with no reason")
+		return nil, nil, time.Time{}, fmt.Errorf("payment promise is invalid with no reason")
 	}
 
 	promiseHash, err := promise.Hash()
 	if err != nil {
-		return nil, nil, fmt.Errorf("computing payment promise hash: %w", err)
+		return nil, nil, time.Time{}, fmt.Errorf("computing payment promise hash: %w", err)
 	}
-	return promise, promiseHash, nil
+
+	return promise, promiseHash, pruneAt, nil
 }
 
 // verifyAssignment verifies that the [types.BlobShard] in the request is assigned to this validator.

--- a/fibre/store.go
+++ b/fibre/store.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/celestiaorg/celestia-app/v6/x/fibre/types"
@@ -74,12 +75,13 @@ func NewBadgerStore(cfg StoreConfig) (*Store, error) {
 
 // Put stores given [PaymentPromise] and [types.BlobShard].
 //
-// Shards are stored as a single blob under /rows/<commitment>/<promise-hash>.
+// Shards are stored as a single blob under /shard/<commitment>/<promise-hash>.
 // The payment promise is stored under /pp/<promise-hash>.
-// An empty value is indexed under /tp/<timestamp-YYYYMMDDHHmm>/<commitment>/<promise-hash> for time-based queries.
+// The pruneAt sets the timestamp used for the /prune/<YYYYMMDDHHmm>/<commitment>/<promise-hash>,
+// determining when the entry will be removed by [PruneBefore].
 //
 // Puts for the same commitments but different promises are allowed and are stored independently without deduplication.
-func (s *Store) Put(ctx context.Context, promise *PaymentPromise, shard *types.BlobShard) error {
+func (s *Store) Put(ctx context.Context, promise *PaymentPromise, shard *types.BlobShard, pruneAt time.Time) error {
 	batch, err := s.ds.Batch(ctx)
 	if err != nil {
 		return fmt.Errorf("creating batch: %w", err)
@@ -103,13 +105,13 @@ func (s *Store) Put(ctx context.Context, promise *PaymentPromise, shard *types.B
 	if err != nil {
 		return fmt.Errorf("marshaling shard: %w", err)
 	}
-	if err := batch.Put(ctx, rowsKey(promise.Commitment, promiseHash), shardData); err != nil {
+	if err := batch.Put(ctx, shardKey(promise.Commitment, promiseHash), shardData); err != nil {
 		return fmt.Errorf("putting shard: %w", err)
 	}
 
-	// write timestamp index
-	if err := batch.Put(ctx, timestampKey(promise.CreationTimestamp, promise.Commitment, promiseHash), []byte{}); err != nil {
-		return fmt.Errorf("putting timestamp index: %w", err)
+	// write prune index
+	if err := batch.Put(ctx, pruneKey(pruneAt, promise.Commitment, promiseHash), []byte{}); err != nil {
+		return fmt.Errorf("putting prune index: %w", err)
 	}
 
 	return batch.Commit(ctx)
@@ -124,7 +126,7 @@ func (s *Store) Put(ctx context.Context, promise *PaymentPromise, shard *types.B
 // Returns an error only if all entries fail to unmarshal or if no shards are found.
 func (s *Store) Get(ctx context.Context, commitment Commitment) (*types.BlobShard, error) {
 	results, err := s.ds.Query(ctx, query.Query{
-		Prefix: fmt.Sprintf("/rows/%s", commitment.String()),
+		Prefix: fmt.Sprintf("/shard/%s", commitment.String()),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("querying shards: %w", err)
@@ -187,6 +189,67 @@ func (s *Store) GetPaymentPromise(ctx context.Context, promiseHash []byte) (*Pay
 	return &promise, nil
 }
 
+// PruneBefore deletes all shards and payment promises with pruneAt before the given time
+// and returns the number of pruned entries.
+//
+// It works by iterating over the ordered prune index and deleting each entry until the given time,
+// so it iterates exactly over the entries that need to be pruned. The order is guaranteed by the
+// underlying database and enforced with query.OrderByKey{}.
+func (s *Store) PruneBefore(ctx context.Context, before time.Time) (int, error) {
+	results, err := s.ds.Query(ctx, query.Query{
+		Prefix:   "/prune/",
+		KeysOnly: true,
+		Orders:   []query.Order{query.OrderByKey{}},
+	})
+	if err != nil {
+		return 0, fmt.Errorf("querying prune index: %w", err)
+	}
+	defer results.Close()
+
+	batch, err := s.ds.Batch(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("creating batch: %w", err)
+	}
+
+	pruned := 0
+	beforeStr := formatTimestamp(before)
+	for result := range results.Next() {
+		if result.Error != nil {
+			return pruned, fmt.Errorf("iterating results: %w", result.Error)
+		}
+
+		// extract timestamp from key: /prune/YYYYMMDDHHmm/...
+		// early termination: keys are sorted, so if timestamp >= cutoff, we're done
+		timestampStr := result.Key[7:19] // skip "/prune/" and take 12 chars
+		if timestampStr >= beforeStr {
+			break
+		}
+
+		// parse key: /prune/<timestamp>/<commitment>/<promise-hash>
+		commitment, promiseHash, ok := parsePruneKey(result.Key)
+		if !ok {
+			continue
+		}
+
+		// delete all related entries
+		if err := batch.Delete(ctx, ds.NewKey(result.Key)); err != nil {
+			return pruned, fmt.Errorf("deleting prune index: %w", err)
+		}
+		if err := batch.Delete(ctx, shardKey(commitment, promiseHash)); err != nil {
+			return pruned, fmt.Errorf("deleting shard: %w", err)
+		}
+		if err := batch.Delete(ctx, promiseKey(promiseHash)); err != nil {
+			return pruned, fmt.Errorf("deleting payment promise: %w", err)
+		}
+		pruned++
+	}
+
+	if err := batch.Commit(ctx); err != nil {
+		return pruned, fmt.Errorf("committing batch: %w", err)
+	}
+	return pruned, nil
+}
+
 // Close closes the underlying datastore.
 func (s *Store) Close() error {
 	return s.ds.Close()
@@ -202,10 +265,32 @@ func promiseKey(promiseHash []byte) ds.Key {
 	return ds.NewKey(fmt.Sprintf("/pp/%s", hex.EncodeToString(promiseHash)))
 }
 
-func rowsKey(commitment Commitment, promiseHash []byte) ds.Key {
-	return ds.NewKey(fmt.Sprintf("/rows/%s/%s", commitment.String(), hex.EncodeToString(promiseHash)))
+func shardKey(commitment Commitment, promiseHash []byte) ds.Key {
+	return ds.NewKey(fmt.Sprintf("/shard/%s/%s", commitment.String(), hex.EncodeToString(promiseHash)))
 }
 
-func timestampKey(timestamp time.Time, commitment Commitment, promiseHash []byte) ds.Key {
-	return ds.NewKey(fmt.Sprintf("/tp/%s/%s/%s", formatTimestamp(timestamp), commitment.String(), hex.EncodeToString(promiseHash)))
+func pruneKey(pruneAt time.Time, commitment Commitment, promiseHash []byte) ds.Key {
+	return ds.NewKey(fmt.Sprintf("/prune/%s/%s/%s", formatTimestamp(pruneAt), commitment.String(), hex.EncodeToString(promiseHash)))
+}
+
+// parsePruneKey extracts commitment and promise hash from a prune index key.
+// Key format: /prune/<timestamp>/<commitment>/<promise-hash>
+func parsePruneKey(key string) (Commitment, []byte, bool) {
+	// split: ["", "prune", "<timestamp>", "<commitment>", "<promise-hash>"]
+	parts := strings.Split(key, "/")
+	if len(parts) != 5 {
+		return Commitment{}, nil, false
+	}
+
+	commitment, err := CommitmentFromString(parts[3])
+	if err != nil {
+		return Commitment{}, nil, false
+	}
+
+	promiseHash, err := hex.DecodeString(parts[4])
+	if err != nil {
+		return Commitment{}, nil, false
+	}
+
+	return commitment, promiseHash, true
 }

--- a/fibre/store_bench_test.go
+++ b/fibre/store_bench_test.go
@@ -1,0 +1,99 @@
+package fibre_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/celestiaorg/celestia-app/v6/fibre"
+	"github.com/celestiaorg/celestia-app/v6/x/fibre/types"
+	"github.com/stretchr/testify/require"
+)
+
+// NOTE: BenchmarkPruneBefore helped to iterate over the few implementations learning the internals of the database
+// until the optimal and scalable one was found.
+func BenchmarkPruneBefore(b *testing.B) {
+	for _, tc := range []struct {
+		name    string
+		entries int
+		prune   int // percent
+	}{
+		{"100_10pct", 100, 10},
+		{"100_50pct", 100, 50},
+		{"1000_10pct", 1000, 10},
+		{"1000_50pct", 1000, 50},
+	} {
+		b.Run(tc.name, func(b *testing.B) {
+			benchmarkPruneBefore(b, tc.entries, tc.prune)
+		})
+	}
+}
+
+func benchmarkPruneBefore(b *testing.B, totalEntries, prunePercent int) {
+	baseTime := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	// pre-generate test data
+	type entry struct {
+		promise *fibre.PaymentPromise
+		shard   *types.BlobShard
+		pruneAt time.Time
+	}
+	entries := make([]entry, totalEntries)
+	for i := range entries {
+		blob := makeBenchBlob(i)
+		entries[i] = entry{
+			promise: makeTestPaymentPromise(uint64(i), blob.Commitment()),
+			shard:   makeBenchShard(blob),
+			pruneAt: baseTime.Add(time.Duration(i) * time.Minute),
+		}
+	}
+
+	cutoffMinute := (totalEntries * prunePercent) / 100
+	cutoffTime := baseTime.Add(time.Duration(cutoffMinute) * time.Minute)
+
+	for b.Loop() {
+		b.StopTimer()
+		store := makeBenchStore(b)
+		for _, e := range entries {
+			_ = store.Put(b.Context(), e.promise, e.shard, e.pruneAt)
+		}
+		b.StartTimer()
+
+		pruned, err := store.PruneBefore(b.Context(), cutoffTime)
+		require.NoError(b, err)
+
+		b.StopTimer()
+		if pruned != cutoffMinute {
+			b.Fatalf("expected %d pruned, got %d", cutoffMinute, pruned)
+		}
+		store.Close()
+		b.StartTimer()
+	}
+}
+
+func makeBenchStore(b *testing.B) *fibre.Store {
+	cfg := fibre.DefaultStoreConfig()
+	cfg.Path = b.TempDir()
+	store, _ := fibre.NewBadgerStore(cfg)
+	return store
+}
+
+func makeBenchBlob(seed int) *fibre.Blob {
+	data := make([]byte, 256)
+	for i := range data {
+		data[i] = byte((seed + i) % 256)
+	}
+	blob, _ := fibre.NewBlob(data, fibre.DefaultBlobConfigV0())
+	return blob
+}
+
+func makeBenchShard(blob *fibre.Blob) *types.BlobShard {
+	row0, _ := blob.Row(0)
+	row1, _ := blob.Row(1)
+	return &types.BlobShard{
+		Rows: []*types.BlobRow{
+			{Index: 0, Data: row0.Row, Proof: row0.RowProof.RowProof},
+			{Index: 1, Data: row1.Row, Proof: row1.RowProof.RowProof},
+		},
+		Rlc: &types.BlobShard_Root{Root: make([]byte, 32)},
+	}
+}

--- a/fibre/store_test.go
+++ b/fibre/store_test.go
@@ -14,30 +14,34 @@ import (
 func TestStore(t *testing.T) {
 	tests := []struct {
 		name string
-		fn   func(*testing.T)
+		fn   func(*testing.T, *fibre.Store)
 	}{
 		{"PutGet_Roundtrip", testStorePutGetRoundtrip},
 		{"Put_SameCommitmentSamePromise", testStorePutSameCommitmentSamePromise},
 		{"Put_SameCommitmentDifferentPromises", testStorePutSameCommitmentDifferentPromises},
 		{"Get_NotFound", testStoreGetNotFound},
+		{"PruneBefore_RemovesShardAndPromise", testStorePruneBeforeRemovesShardAndPromise},
+		{"PruneBefore_PreservesOtherPromiseShard", testStorePruneBeforePreservesOtherPromiseShard},
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, tt.fn)
+		t.Run(tt.name, func(t *testing.T) {
+			store := makeTestStore(t)
+			tt.fn(t, store)
+		})
 	}
 }
 
-func testStorePutGetRoundtrip(t *testing.T) {
+func testStorePutGetRoundtrip(t *testing.T, store *fibre.Store) {
 	ctx := t.Context()
-	store := fibre.NewMemoryStore(fibre.DefaultStoreConfig())
 
 	blob := makeTestBlobV0(t, 256)
 	commitment := blob.Commitment()
-	shard := makeRowsFrom(t, blob, 0, 1, 2)
+	shard := makeShardFrom(t, blob, 0, 1, 2)
 	promise := makeTestPaymentPromise(100, commitment)
 
 	// put data
-	err := store.Put(ctx, promise, shard)
+	err := store.Put(ctx, promise, shard, promise.CreationTimestamp)
 	require.NoError(t, err)
 
 	// get shard by commitment
@@ -58,21 +62,20 @@ func testStorePutGetRoundtrip(t *testing.T) {
 	require.Equal(t, promise.Commitment, gotPromise.Commitment)
 }
 
-func testStorePutSameCommitmentSamePromise(t *testing.T) {
+func testStorePutSameCommitmentSamePromise(t *testing.T, store *fibre.Store) {
 	ctx := t.Context()
-	store := fibre.NewMemoryStore(fibre.DefaultStoreConfig())
 
 	blob := makeTestBlobV0(t, 256)
 	commitment := blob.Commitment()
-	shard := makeRowsFrom(t, blob, 0, 1)
+	shard := makeShardFrom(t, blob, 0, 1)
 	promise := makeTestPaymentPromise(100, commitment)
 
 	// put data first time
-	err := store.Put(ctx, promise, shard)
+	err := store.Put(ctx, promise, shard, promise.CreationTimestamp)
 	require.NoError(t, err)
 
 	// put the same data again (same commitment, same promise)
-	err = store.Put(ctx, promise, shard)
+	err = store.Put(ctx, promise, shard, promise.CreationTimestamp)
 	require.NoError(t, err)
 
 	// should be able to retrieve
@@ -82,17 +85,16 @@ func testStorePutSameCommitmentSamePromise(t *testing.T) {
 	require.Len(t, gotShard.Rows, 2)
 }
 
-func testStorePutSameCommitmentDifferentPromises(t *testing.T) {
+func testStorePutSameCommitmentDifferentPromises(t *testing.T, store *fibre.Store) {
 	ctx := t.Context()
-	store := fibre.NewMemoryStore(fibre.DefaultStoreConfig())
 
 	// create a single blob to get the same commitment
 	blob := makeTestBlobV0(t, 256)
 	commitment := blob.Commitment()
 
-	// extract different row sets from the same blob
-	shard1 := makeRowsFrom(t, blob, 0, 1)
-	shard2 := makeRowsFrom(t, blob, 2, 3)
+	// extract different shards from the same blob
+	shard1 := makeShardFrom(t, blob, 0, 1)
+	shard2 := makeShardFrom(t, blob, 2, 3)
 
 	// first promise with rows 0, 1
 	promise1 := makeTestPaymentPromise(100, commitment)
@@ -101,11 +103,11 @@ func testStorePutSameCommitmentDifferentPromises(t *testing.T) {
 	promise2 := makeTestPaymentPromise(101, commitment)
 
 	// put first promise
-	err := store.Put(ctx, promise1, shard1)
+	err := store.Put(ctx, promise1, shard1, promise1.CreationTimestamp)
 	require.NoError(t, err)
 
 	// put second promise with same commitment but different promise
-	err = store.Put(ctx, promise2, shard2)
+	err = store.Put(ctx, promise2, shard2, promise2.CreationTimestamp)
 	require.NoError(t, err)
 
 	// get should return combined rows from both promises
@@ -138,9 +140,8 @@ func testStorePutSameCommitmentDifferentPromises(t *testing.T) {
 	require.Equal(t, promise2.Height, gotPromise2.Height)
 }
 
-func testStoreGetNotFound(t *testing.T) {
+func testStoreGetNotFound(t *testing.T, store *fibre.Store) {
 	ctx := t.Context()
-	store := fibre.NewMemoryStore(fibre.DefaultStoreConfig())
 
 	// create commitment that was never stored
 	blob := makeTestBlobV0(t, 256)
@@ -151,8 +152,92 @@ func testStoreGetNotFound(t *testing.T) {
 	require.ErrorIs(t, err, fibre.ErrStoreNotFound)
 }
 
-// makeRowsFrom extracts rows from a blob at the given indices.
-func makeRowsFrom(t *testing.T, blob *fibre.Blob, indices ...int) *types.BlobShard {
+func testStorePruneBeforeRemovesShardAndPromise(t *testing.T, store *fibre.Store) {
+	ctx := t.Context()
+
+	blob := makeTestBlobV0(t, 256)
+	commitment := blob.Commitment()
+	shard := makeShardFrom(t, blob, 0, 1)
+	promise := makeTestPaymentPromise(100, commitment)
+
+	pruneAt := time.Date(2025, 1, 1, 10, 0, 0, 0, time.UTC)
+	cutoffTime := time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC)
+
+	err := store.Put(ctx, promise, shard, pruneAt)
+	require.NoError(t, err)
+
+	// verify exists
+	promiseHash, _ := promise.Hash()
+	_, err = store.GetPaymentPromise(ctx, promiseHash)
+	require.NoError(t, err)
+	_, err = store.Get(ctx, commitment)
+	require.NoError(t, err)
+
+	// prune
+	pruned, err := store.PruneBefore(ctx, cutoffTime)
+	require.NoError(t, err)
+	require.Equal(t, 1, pruned)
+
+	// both promise and shard should be gone
+	_, err = store.GetPaymentPromise(ctx, promiseHash)
+	require.Error(t, err)
+	_, err = store.Get(ctx, commitment)
+	require.ErrorIs(t, err, fibre.ErrStoreNotFound)
+}
+
+func testStorePruneBeforePreservesOtherPromiseShard(t *testing.T, store *fibre.Store) {
+	ctx := t.Context()
+
+	blob := makeTestBlobV0(t, 256)
+	commitment := blob.Commitment()
+
+	oldPruneAt := time.Date(2025, 1, 1, 10, 0, 0, 0, time.UTC)
+	cutoffTime := time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC)
+	newPruneAt := time.Date(2025, 1, 1, 14, 0, 0, 0, time.UTC)
+
+	// two promises with different shards for the same commitment
+	oldPromise := makeTestPaymentPromise(100, commitment)
+	newPromise := makeTestPaymentPromise(101, commitment)
+	oldShard := makeShardFrom(t, blob, 0, 1)
+	newShard := makeShardFrom(t, blob, 2, 3)
+
+	err := store.Put(ctx, oldPromise, oldShard, oldPruneAt)
+	require.NoError(t, err)
+	err = store.Put(ctx, newPromise, newShard, newPruneAt)
+	require.NoError(t, err)
+
+	oldHash, _ := oldPromise.Hash()
+	newHash, _ := newPromise.Hash()
+
+	// prune old
+	pruned, err := store.PruneBefore(ctx, cutoffTime)
+	require.NoError(t, err)
+	require.Equal(t, 1, pruned)
+
+	// old promise gone
+	_, err = store.GetPaymentPromise(ctx, oldHash)
+	require.Error(t, err)
+
+	// new promise and its shard still exist
+	_, err = store.GetPaymentPromise(ctx, newHash)
+	require.NoError(t, err)
+	gotShard, err := store.Get(ctx, commitment)
+	require.NoError(t, err)
+	require.Equal(t, uint32(2), gotShard.Rows[0].Index)
+}
+
+func makeTestStore(t *testing.T) *fibre.Store {
+	t.Helper()
+	cfg := fibre.DefaultStoreConfig()
+	cfg.Path = t.TempDir()
+	store, err := fibre.NewBadgerStore(cfg)
+	require.NoError(t, err)
+	t.Cleanup(func() { store.Close() })
+	return store
+}
+
+// makeShardFrom extracts a shard from a blob at the given row indices.
+func makeShardFrom(t *testing.T, blob *fibre.Blob, indices ...int) *types.BlobShard {
 	t.Helper()
 
 	rows := make([]*types.BlobRow, len(indices))
@@ -172,6 +257,8 @@ func makeRowsFrom(t *testing.T, blob *fibre.Blob, indices ...int) *types.BlobSha
 	}
 }
 
+var testSignerKey = secp256k1.GenPrivKey().PubKey().(*secp256k1.PubKey)
+
 // makeTestPaymentPromise creates a test payment promise for store tests.
 func makeTestPaymentPromise(height uint64, commitment fibre.Commitment) *fibre.PaymentPromise {
 	return &fibre.PaymentPromise{
@@ -181,7 +268,7 @@ func makeTestPaymentPromise(height uint64, commitment fibre.Commitment) *fibre.P
 		UploadSize:        1024,
 		Commitment:        commitment,
 		CreationTimestamp: time.Date(2025, 10, 21, 15, 30, 0, 0, time.UTC),
-		SignerKey:         secp256k1.GenPrivKey().PubKey().(*secp256k1.PubKey),
+		SignerKey:         testSignerKey,
 		Signature:         []byte("test-signature-64-bytes-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"),
 	}
 }

--- a/multiplexer/abci/multiplexer.go
+++ b/multiplexer/abci/multiplexer.go
@@ -193,6 +193,8 @@ func (m *Multiplexer) enableGRPCAndAPIServers(app servertypes.Application) error
 			if err != nil {
 				return fmt.Errorf("failed to start Fibre server: %w", err)
 			}
+			fibreServer.Start()
+
 			maxMsgSize := fibre.MaxMessageSize(serverConfig.BlobConfig)
 			m.svrCfg.GRPC.MaxRecvMsgSize = maxMsgSize
 			m.svrCfg.GRPC.MaxSendMsgSize = maxMsgSize


### PR DESCRIPTION
Adds `PruneBefore` method into Store and the pruning loop in Server that triggers the method every minute.

The pruning logic was benchmarked and optimized to the point that it iterates only over the entries to remove, leveraging the lexicographic ordering of keys in the index. 

The pruning index is updated to keep timestamps, not the PP creation time, but the time the data is supposed to be removed, as reported by the state module (future change).