### PR TITLE
refactor(fibre): extract protocol params

### DIFF
--- a/cmd/celestia-appd/cmd/start_command_standalone.go
+++ b/cmd/celestia-appd/cmd/start_command_standalone.go
@@ -111,9 +111,8 @@ func startCommandHandler(
 		}
 		fibreServer.Start()
 
-		maxMsgSize := fibre.MaxMessageSize(serverConfig.BlobConfig)
-		svrCfg.GRPC.MaxRecvMsgSize = maxMsgSize
-		svrCfg.GRPC.MaxSendMsgSize = maxMsgSize
+		svrCfg.GRPC.MaxRecvMsgSize = serverConfig.MaxMessageSize
+		svrCfg.GRPC.MaxSendMsgSize = serverConfig.MaxMessageSize
 
 		// Now start the gRPC server (after all services are registered)
 		if err := startGRPCServer(ctx, g, svrCtx, svrCfg, grpcServer, cmtNode); err != nil {

--- a/fibre/blob.go
+++ b/fibre/blob.go
@@ -1,7 +1,6 @@
 package fibre
 
 import (
-	"crypto/sha256"
 	"encoding/binary"
 	"encoding/hex"
 	"errors"
@@ -12,7 +11,7 @@ import (
 	"github.com/celestiaorg/rsema1d/field"
 )
 
-// ErrBlobTooLarge is returned when the blob size exceeds MaxBlobSize.
+// ErrBlobTooLarge is returned when the blob size exceeds BlobConfig.MaxDataSize.
 var ErrBlobTooLarge = errors.New("blob size exceeds maximum allowed size")
 
 // Commitment is a commitment to a blob.
@@ -51,96 +50,51 @@ func (c Commitment) Equals(other Commitment) bool {
 	return c == other
 }
 
-// BlobConfig contains constant configuration parameters for blob encoding and decoding.
+// BlobConfig contains configuration parameters for blob encoding and decoding.
 type BlobConfig struct {
+	// BlobVersion is the version of the row format.
+	BlobVersion uint8
 	// OriginalRows is the number of original rows before erasure coding (K in rsema1d).
 	OriginalRows int
 	// ParityRows is the number of parity rows added by erasure coding (N in rsema1d).
 	// Total rows = OriginalRows + ParityRows.
 	ParityRows int
-	// RowSizeMin is the minimum row size in bytes.
-	RowSizeMin int
-	// MaxBlobSize is the maximum allowed blob size.
-	MaxBlobSize int
-	// BlobVersion is the version of the row format.
-	BlobVersion uint8
+	// RowSize computes row size given the data length.
+	RowSize func(dataLen int) int
+	// MaxDataSize is the maximum data size that can be passed to NewBlob.
+	MaxDataSize int
 	// CodingWorkers is the number of workers to use for encoding and decoding rsema1d.
 	CodingWorkers int
-	// ShardingFactor is the expected number of validators in the network.
-	// This is used to calculate the maximum gRPC message size per validator.
-	// Should be set to match the expected validator set size.
-	ShardingFactor int
 }
 
 // DefaultBlobConfigV0 returns a [BlobConfig] with default values for version 0.
 func DefaultBlobConfigV0() BlobConfig {
+	return NewBlobConfigFromParams(0, DefaultProtocolParams)
+}
+
+// NewBlobConfigFromParams creates a [BlobConfig] with values derived from the given [ProtocolParams].
+// Use this when you need a config with non-default protocol parameters (e.g., for testing).
+func NewBlobConfigFromParams(blobVersion uint8, p ProtocolParams) BlobConfig {
+	if blobVersion != 0 {
+		panic(fmt.Sprintf("unsupported blob version: %d", blobVersion))
+	}
+
 	return BlobConfig{
-		OriginalRows:   4096,
-		ParityRows:     12288, // (3 * OriginalRows, TotalRows = 16384)
-		RowSizeMin:     64,
-		MaxBlobSize:    128 * 1024 * 1024,
-		BlobVersion:    0,
-		CodingWorkers:  runtime.GOMAXPROCS(0),
-		ShardingFactor: 100, // Expected number of validators
+		BlobVersion:  blobVersion,
+		OriginalRows: p.Rows,
+		ParityRows:   p.ParityRows(),
+		RowSize: func(dataLen int) int {
+			return p.RowSize(blobVersion, dataLen+blobHeaderLen)
+		},
+		MaxDataSize:   p.MaxBlobSize - blobHeaderLen, // subtract the header overhead
+		CodingWorkers: runtime.GOMAXPROCS(0),
 	}
-}
-
-// RowSize computes the row size for the given data length and config.
-// Row size is calculated as ceil((dataLen + headerSize) / OriginalRows),
-// rounded up to the nearest multiple of RowSizeMin.
-func (c BlobConfig) RowSize(dataLen int) int {
-	if dataLen == 0 {
-		return 0
-	}
-
-	totalLen := dataLen + blobHeaderLen
-	rowSize := (totalLen + c.OriginalRows - 1) / c.OriginalRows // ceil(totalLen / OriginalRows)
-
-	// round up to nearest multiple of RowSizeMin
-	if rowSize%c.RowSizeMin != 0 {
-		rowSize = ((rowSize / c.RowSizeMin) + 1) * c.RowSizeMin
-	}
-
-	return rowSize
-}
-
-// MaxRowSize calculates the maximum allowed row size based on MaxBlobSize and OriginalRows.
-// This is the row size that would result from encoding a blob of MaxBlobSize.
-func (c BlobConfig) MaxRowSize() int {
-	return c.RowSize(c.MaxBlobSize)
 }
 
 // UploadSize calculates size of blob data with padding and w/o parity.
 // This is the size included in the [PaymentPromise] and the one actually paid for.
 func (c BlobConfig) UploadSize(dataLen int) int {
 	return c.RowSize(dataLen) * c.OriginalRows
-}
-
-// MaxShardSize calculates the maximum size of a shard (subset of blob rows assigned to a validator with RLC and Merkle proofs)
-// This does not include protocol overhead like PaymentPromise or protobuf encoding overhead.
-func (c BlobConfig) MaxShardSize() int {
-	const (
-		rowIndexSize = 4  // uint32 index per row
-		rlcCoeffSize = 16 // uint128 coefficient per row
-	)
-
-	totalRows := c.OriginalRows + c.ParityRows
-	maxRowSize := c.MaxRowSize()
-	rlcCoeffsSize := c.OriginalRows * rlcCoeffSize
-
-	// get proof size per row by finding merkle tree depth
-	treeDepth := 0
-	for n := totalRows; n > 1; n = (n + 1) / 2 {
-		treeDepth++
-	}
-	proofSizePerRow := treeDepth * sha256.Size
-
-	// calculate rows per validator based on sharding factor
-	// add 1 to account for potential uneven distribution
-	// TODO(@Wondertan): This is not completely accurate, but it's a good approximation for now.
-	rowsPerValidator := (totalRows / c.ShardingFactor) + 1
-
-	return rlcCoeffsSize + (rowsPerValidator * (rowIndexSize + maxRowSize + proofSizePerRow))
 }
 
 // Blob represents encoded data with Reed-Solomon erasure coding.
@@ -163,13 +117,13 @@ type Blob struct {
 // NewBlob creates a new [Blob] instance by encoding the data.
 // It takes the data and a [BlobConfig].
 // The data is prefixed with a header containing the blob version and data size.
-// Returns [ErrBlobTooLarge] if the data size exceeds the maximum allowed size.
+// Returns [ErrBlobTooLarge] if the data size exceeds BlobConfig.MaxDataSize.
 func NewBlob(data []byte, cfg BlobConfig) (d *Blob, err error) {
 	if len(data) == 0 {
 		return nil, fmt.Errorf("data cannot be empty")
 	}
-	if len(data) > cfg.MaxBlobSize {
-		return nil, fmt.Errorf("%w: data size %d exceeds maximum %d", ErrBlobTooLarge, len(data), cfg.MaxBlobSize)
+	if len(data) > cfg.MaxDataSize {
+		return nil, fmt.Errorf("%w: data size %d exceeds maximum %d", ErrBlobTooLarge, len(data), cfg.MaxDataSize)
 	}
 
 	d = &Blob{
@@ -195,6 +149,11 @@ func NewBlob(data []byte, cfg BlobConfig) (d *Blob, err error) {
 // Commitment returns the commitment to the blob.
 func (d *Blob) Commitment() Commitment {
 	return d.commitment
+}
+
+// Config returns the blob's configuration.
+func (d *Blob) Config() BlobConfig {
+	return d.cfg
 }
 
 // RLCCoeffs returns RLC coefficients of the original data.
@@ -321,8 +280,8 @@ func (h *blobHeaderV0) decodeFromRows(rows [][]byte, cfg BlobConfig) ([]byte, er
 	if h.dataSize == 0 {
 		return nil, fmt.Errorf("invalid blob size in header: must be greater than 0")
 	}
-	if int(h.dataSize) > cfg.MaxBlobSize {
-		return nil, fmt.Errorf("blob size in header (%d bytes) exceeds maximum allowed size (%d bytes)", h.dataSize, cfg.MaxBlobSize)
+	if int(h.dataSize) > cfg.MaxDataSize {
+		return nil, fmt.Errorf("blob size in header (%d bytes) exceeds maximum allowed size (%d bytes)", h.dataSize, cfg.MaxDataSize)
 	}
 
 	dataSize := int(h.dataSize)

--- a/fibre/blob_test.go
+++ b/fibre/blob_test.go
@@ -4,122 +4,19 @@ import (
 	"testing"
 )
 
-func TestBlobConfig_RowSize(t *testing.T) {
-	tests := []struct {
-		name         string
-		dataLen      int
-		originalRows int
-		rowSizeMin   int
-		wantRowSize  int
-	}{
-		{
-			name:         "exact fit",
-			dataLen:      64*8 - blobHeaderLen, // Exactly fits in 8 rows of 64 bytes
-			originalRows: 8,
-			rowSizeMin:   64,
-			wantRowSize:  64,
-		},
-		{
-			name:         "needs rounding up",
-			dataLen:      100,
-			originalRows: 8,
-			rowSizeMin:   64,
-			wantRowSize:  64, // ceil((100+5)/8) = 14, rounded up to 64
-		},
-		{
-			name:         "small data",
-			dataLen:      1,
-			originalRows: 8,
-			rowSizeMin:   64,
-			wantRowSize:  64, // ceil((1+5)/8) = 1, rounded up to 64
-		},
-		{
-			name:         "large data",
-			dataLen:      10000,
-			originalRows: 8,
-			rowSizeMin:   64,
-			wantRowSize:  1280, // ceil((10000+5)/8) = 1251, rounded up to 1280 (1251/64=19.5, so 20*64)
-		},
-		{
-			name:         "different row size min",
-			dataLen:      1000,
-			originalRows: 4,
-			rowSizeMin:   128,
-			wantRowSize:  256, // ceil((1000+5)/4) = 252, rounded up to 256 (252/128=1.97, so 2*128)
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			cfg := BlobConfig{
-				OriginalRows: tt.originalRows,
-				RowSizeMin:   tt.rowSizeMin,
-			}
-
-			rowSize := cfg.RowSize(tt.dataLen)
-			if rowSize != tt.wantRowSize {
-				t.Errorf("RowSize(%d) = %d, want %d", tt.dataLen, rowSize, tt.wantRowSize)
-			}
-
-			// verify row size is multiple of RowSizeMin
-			if rowSize%tt.rowSizeMin != 0 {
-				t.Errorf("RowSize(%d) = %d, not a multiple of %d", tt.dataLen, rowSize, tt.rowSizeMin)
-			}
-		})
-	}
-}
-
 func TestBlobHeaderV0_EncodeToRows_DecodeFromRows(t *testing.T) {
+	cfg := DefaultBlobConfigV0()
+
 	tests := []struct {
 		name     string
 		dataSize int
-		cfg      BlobConfig
 	}{
-		{
-			name:     "small data",
-			dataSize: 10,
-			cfg: BlobConfig{
-				OriginalRows: 4,
-				RowSizeMin:   64,
-				MaxBlobSize:  10000,
-			},
-		},
-		{
-			name:     "medium data",
-			dataSize: 500,
-			cfg: BlobConfig{
-				OriginalRows: 8,
-				RowSizeMin:   64,
-				MaxBlobSize:  10000,
-			},
-		},
-		{
-			name:     "large data",
-			dataSize: 5000,
-			cfg: BlobConfig{
-				OriginalRows: 16,
-				RowSizeMin:   64,
-				MaxBlobSize:  10000,
-			},
-		},
-		{
-			name:     "single byte",
-			dataSize: 1,
-			cfg: BlobConfig{
-				OriginalRows: 8,
-				RowSizeMin:   64,
-				MaxBlobSize:  10000,
-			},
-		},
-		{
-			name:     "exact multiple",
-			dataSize: 64*8 - blobHeaderLen,
-			cfg: BlobConfig{
-				OriginalRows: 8,
-				RowSizeMin:   64,
-				MaxBlobSize:  10000,
-			},
-		},
+		{"single byte", 1},
+		{"small data", 10},
+		{"medium data", 500},
+		{"large data", 5000},
+		{"1 KiB", 1024},
+		{"1 MiB", 1024 * 1024},
 	}
 
 	for _, tt := range tests {
@@ -132,15 +29,15 @@ func TestBlobHeaderV0_EncodeToRows_DecodeFromRows(t *testing.T) {
 
 			// Encode
 			header := newBlobHeaderV0(len(data))
-			rows := header.encodeToRows(data, tt.cfg)
+			rows := header.encodeToRows(data, cfg)
 
 			// Verify correct number of rows
-			if len(rows) != tt.cfg.OriginalRows {
-				t.Fatalf("encodeToRows() returned %d rows, want %d", len(rows), tt.cfg.OriginalRows)
+			if len(rows) != cfg.OriginalRows {
+				t.Fatalf("encodeToRows() returned %d rows, want %d", len(rows), cfg.OriginalRows)
 			}
 
 			// Verify all rows have same size
-			expectedRowSize := tt.cfg.RowSize(len(data))
+			expectedRowSize := cfg.RowSize(len(data))
 			for i, row := range rows {
 				if len(row) != expectedRowSize {
 					t.Errorf("row %d size = %d, want %d", i, len(row), expectedRowSize)
@@ -149,7 +46,7 @@ func TestBlobHeaderV0_EncodeToRows_DecodeFromRows(t *testing.T) {
 
 			// Decode
 			var decodeHeader blobHeaderV0
-			decodedData, err := decodeHeader.decodeFromRows(rows, tt.cfg)
+			decodedData, err := decodeHeader.decodeFromRows(rows, cfg)
 			if err != nil {
 				t.Fatalf("decodeFromRows() error = %v", err)
 			}

--- a/fibre/client.go
+++ b/fibre/client.go
@@ -35,13 +35,14 @@ type ClientConfig struct {
 	// ChainID is the chain identifier for domain separation in [PaymentPromise] signatures.
 	ChainID string
 
-	// BlobConfig contains erasure coding and data handling configuration.
-	BlobConfig
+	// MaxMessageSize is the maximum gRPC message size for upload requests.
+	MaxMessageSize int
 
 	// UploadTargetVotingPower is the fraction (e.g., 2/3) of total voting power required for Upload operations.
 	UploadTargetVotingPower cmtmath.Fraction
 	// UploadTargetSignaturesCount is the fraction (e.g., 2/3) of total signature count required for Upload operations.
 	UploadTargetSignaturesCount cmtmath.Fraction
+
 	// UploadConcurrency is the maximum number of concurrent uploads to validators.
 	UploadConcurrency int
 	// DownloadConcurrency is the maximum number of concurrent read requests to validators.
@@ -62,15 +63,22 @@ type ClientConfig struct {
 }
 
 // DefaultClientConfig returns a [ClientConfig] with the default values.
+// Values are derived from DefaultProtocolParams.
 func DefaultClientConfig() ClientConfig {
+	return NewClientConfigFromParams(DefaultProtocolParams)
+}
+
+// NewClientConfigFromParams creates a ClientConfig with values derived from the given ProtocolParams.
+// Use this when you need a config with non-default protocol parameters (e.g., for testing).
+func NewClientConfigFromParams(p ProtocolParams) ClientConfig {
 	return ClientConfig{
 		DefaultKeyName:              DefaultKeyName,
 		ChainID:                     "celestia",
-		BlobConfig:                  DefaultBlobConfigV0(),
-		UploadTargetVotingPower:     cmtmath.Fraction{Numerator: 2, Denominator: 3},
-		UploadTargetSignaturesCount: cmtmath.Fraction{Numerator: 2, Denominator: 3},
-		UploadConcurrency:           100, // matches expected number of validators to maximize throughput by default
-		DownloadConcurrency:         25,  // 1/4 of validators to match 1/3 erasure coding overhead and request the minimum number of samples to get the data
+		MaxMessageSize:              p.MaxMessageSize(p.MaxValidatorCount),
+		UploadTargetVotingPower:     p.SafetyThreshold,
+		UploadTargetSignaturesCount: p.SafetyThreshold,
+		UploadConcurrency:           p.MaxValidatorCount,
+		DownloadConcurrency:         p.ShardsForReconstruction(p.MaxValidatorCount),
 	}
 }
 
@@ -109,7 +117,7 @@ func NewClient(txClient *user.TxClient, kr keyring.Keyring, valGet validator.Set
 	}
 
 	if cfg.NewClientFn == nil {
-		cfg.NewClientFn = grpc.DefaultNewClientFn(hostReg, MaxMessageSize(cfg.BlobConfig))
+		cfg.NewClientFn = grpc.DefaultNewClientFn(hostReg, cfg.MaxMessageSize)
 	}
 	if cfg.Tracer == nil {
 		cfg.Tracer = otel.Tracer("fibre-client")
@@ -152,10 +160,4 @@ func (c *Client) Close() error {
 
 	c.closeWg.Wait()
 	return c.clientCache.Close()
-}
-
-// MaxMessageSize returns the maximum message size that can be sent over the network.
-func MaxMessageSize(cfg BlobConfig) int {
-	msgSize := cfg.MaxShardSize() + MaxPaymentPromiseSize
-	return msgSize + (msgSize / 50) // add 2% protobuf overhead
 }

--- a/fibre/client_put.go
+++ b/fibre/client_put.go
@@ -40,7 +40,7 @@ func (c *Client) Put(ctx context.Context, ns share.Namespace, data []byte) (resu
 	defer span.End()
 
 	// encoding section
-	blob, err := NewBlob(data, c.cfg.BlobConfig)
+	blob, err := NewBlob(data, DefaultBlobConfigV0())
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, "failed to encode blob")

--- a/fibre/client_server_test.go
+++ b/fibre/client_server_test.go
@@ -83,12 +83,13 @@ func makeTestEnv(
 		ValidatorSet: core.NewValidatorSet(validators),
 		Height:       100,
 	}
+	testParams := fibre.DefaultProtocolParams
+	testParams.MaxValidatorCount = numValidators
 
-	grpcServers, stores, addresses := makeTestServers(t, validators, privKeys, valSet, modifyServerConfig)
+	grpcServers, stores, addresses := makeTestServers(t, validators, privKeys, valSet, testParams, modifyServerConfig)
 	clients := make([]*fibre.Client, numClients)
 	for i := range numClients {
-		clientCfg := fibre.DefaultClientConfig()
-		clientCfg.ShardingFactor = numValidators
+		clientCfg := fibre.NewClientConfigFromParams(testParams)
 
 		// create logger with unique client identifier
 		clientCfg.Log = slog.Default().With("client_idx", i)
@@ -97,7 +98,7 @@ func makeTestEnv(
 		if modifyClientConfig != nil {
 			modifyClientConfig(&clientCfg)
 		}
-		clientCfg.NewClientFn = grpcfibre.DefaultNewClientFn(&testHostRegistry{addresses: addresses}, fibre.MaxMessageSize(clientCfg.BlobConfig))
+		clientCfg.NewClientFn = grpcfibre.DefaultNewClientFn(&testHostRegistry{addresses: addresses}, clientCfg.MaxMessageSize)
 
 		client, err := fibre.NewClient(nil, makeTestKeyring(t), &mockValidatorSetGetter{set: valSet}, &mockHostRegistry{}, clientCfg)
 		require.NoError(t, err)
@@ -118,6 +119,7 @@ func makeTestServers(
 	validators []*core.Validator,
 	privKeys []cmted25519.PrivKey,
 	valSet validator.Set,
+	params fibre.ProtocolParams,
 	modifyServerConfig func(*fibre.ServerConfig),
 ) ([]*grpc.Server, []*fibre.Store, map[string]string) {
 	t.Helper()
@@ -130,8 +132,7 @@ func makeTestServers(
 		listener, err := net.Listen("tcp", "127.0.0.1:0")
 		require.NoError(t, err)
 
-		serverCfg := fibre.DefaultServerConfig()
-		serverCfg.ShardingFactor = len(validators)
+		serverCfg := fibre.NewServerConfigFromParams(params)
 
 		// create logger with unique server identifier
 		serverCfg.Log = slog.Default().With(
@@ -153,7 +154,7 @@ func makeTestServers(
 		)
 		require.NoError(t, err)
 
-		maxMsgSize := fibre.MaxMessageSize(fibreServer.Config().BlobConfig)
+		maxMsgSize := serverCfg.MaxMessageSize
 		grpcServer := grpc.NewServer(
 			grpc.MaxRecvMsgSize(maxMsgSize),
 			grpc.MaxSendMsgSize(maxMsgSize),

--- a/fibre/client_server_upload_test.go
+++ b/fibre/client_server_upload_test.go
@@ -22,10 +22,10 @@ func TestClientServerUpload(t *testing.T) {
 	}{
 		{
 			name:           "MaxBlobSize",
-			numValidators:  1,
+			numValidators:  100,
 			numClients:     2,
 			blobsPerClient: 1,
-			blobSize:       fibre.DefaultBlobConfigV0().MaxBlobSize,
+			blobSize:       fibre.DefaultBlobConfigV0().MaxDataSize,
 		},
 		{
 			name:           "MinBlobSize",
@@ -64,7 +64,7 @@ func TestClientServerUpload(t *testing.T) {
 						return fmt.Errorf("generating random data for blob %d: %w", blobIdx, err)
 					}
 
-					blob, err := fibre.NewBlob(data, client.Config().BlobConfig)
+					blob, err := fibre.NewBlob(data, fibre.DefaultBlobConfigV0())
 					if err != nil {
 						return fmt.Errorf("creating blob %d: %w", blobIdx, err)
 					}

--- a/fibre/client_upload.go
+++ b/fibre/client_upload.go
@@ -67,7 +67,8 @@ func (c *Client) Upload(ctx context.Context, ns share.Namespace, blob *Blob) (re
 	))
 
 	// 2) assign shards to validators
-	shardMap := valSet.Assign(rsema1d.Commitment(blob.Commitment()), c.cfg.OriginalRows+c.cfg.ParityRows)
+	blobCfg := blob.Config()
+	shardMap := valSet.Assign(rsema1d.Commitment(blob.Commitment()), blobCfg.OriginalRows+blobCfg.ParityRows)
 	span.AddEvent("shards_assigned")
 
 	signBytes, err := promise.SignBytes()
@@ -158,7 +159,7 @@ func (c *Client) signedPromise(ns share.Namespace, blob *Blob, height uint64) (*
 		Height:            height,
 		Namespace:         ns,
 		UploadSize:        uint32(blob.UploadSize()),
-		BlobVersion:       uint32(c.cfg.BlobVersion),
+		BlobVersion:       uint32(blob.Config().BlobVersion),
 		Commitment:        blob.Commitment(),
 		CreationTimestamp: c.clock.Now().UTC(),
 		SignerKey:         signerKey,

--- a/fibre/client_upload_bench_test.go
+++ b/fibre/client_upload_bench_test.go
@@ -68,7 +68,7 @@ func BenchmarkClient_Upload(b *testing.B) {
 			require.NoError(b, err)
 
 			for b.Loop() {
-				blob, err := fibre.NewBlob(data, client.Config().BlobConfig)
+				blob, err := fibre.NewBlob(data, fibre.DefaultBlobConfigV0())
 				require.NoError(b, err)
 
 				result, err := client.Upload(ctx, namespace, blob)
@@ -142,7 +142,7 @@ func BenchmarkClient_Upload_Concurrent(b *testing.B) {
 				errChan := make(chan error, bm.concurrency)
 				for range bm.concurrency {
 					go func() {
-						blob, err := fibre.NewBlob(data, client.Config().BlobConfig)
+						blob, err := fibre.NewBlob(data, fibre.DefaultBlobConfigV0())
 						require.NoError(b, err)
 
 						_, err = client.Upload(ctx, namespace, blob)

--- a/fibre/protocol_params.go
+++ b/fibre/protocol_params.go
@@ -55,21 +55,17 @@ type ProtocolParams struct {
 
 // DefaultProtocolParams contains the default protocol parameters for version 0.
 var DefaultProtocolParams = ProtocolParams{
-	// Erasure coding: 2^12 original rows, 3x parity (12288 parity rows, 16384 total)
-	Rows:          1 << 12,
-	EncodingRatio: 0.25,
+	Rows:          1 << 12, // 4096 original rows
+	EncodingRatio: 0.25,    // 3x parity (12288 parity rows, 16384 total)
 
-	// Network: 100 validators
 	MaxValidatorCount: 100,
 
-	// Security: 100 bits, 2/3 safety, 1/3 liveness
 	UniqueDecodingSecurityBits: 100,
 	SafetyThreshold:            cmtmath.Fraction{Numerator: 2, Denominator: 3},
 	LivenessThreshold:          cmtmath.Fraction{Numerator: 1, Denominator: 3},
 
-	// Size: 128 MiB max blob s(2^27), 64 byte minimum row size
-	MaxBlobSize: 1 << 27,
-	MinRowSize:  1 << 6,
+	MaxBlobSize: 1 << 27, // 128 MiB
+	MinRowSize:  1 << 6,  // 64 byte
 }
 
 func init() {

--- a/fibre/protocol_params.go
+++ b/fibre/protocol_params.go
@@ -1,0 +1,187 @@
+package fibre
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"math"
+	"math/bits"
+
+	cmtmath "github.com/cometbft/cometbft/libs/math"
+)
+
+// ProtocolParams defines the fundamental protocol constants from which all other
+// configuration values are derived. This provides a single source of truth for
+// protocol parameterization.
+//
+// The design separates "root constants" (what we chose) from "derived values"
+// (what follows from our choices). This enables:
+//   - Clear documentation of protocol design decisions
+//   - Single source of truth for protocol constants
+//   - Easy versioning
+//   - Testing with non-default parameter values
+type ProtocolParams struct {
+	// Erasure coding parameters
+	//
+	// Rows is the number of original data rows (K in rsema1d).
+	Rows int
+	// EncodingRatio is K/(K+N), the fraction of total rows that are original.
+	// For example, 0.25 means 1/4 of total rows are original (so 3/4 are parity).
+	EncodingRatio float64
+
+	// Network parameters
+	//
+	// MaxValidatorCount is the maximum expected number of validators in the network.
+	// Used to compute default values for MaxMessageSize and concurrency limits.
+	MaxValidatorCount int
+
+	// Security parameters
+	//
+	// UniqueDecodingSecurityBits defines how likely it is for unique decoding to fail.
+	UniqueDecodingSecurityBits int
+	// SafetyThreshold is the fraction of voting power required for safety (typically 2/3).
+	// The minimum percentage of stake needed to cause a safety failure.
+	SafetyThreshold cmtmath.Fraction
+	// LivenessThreshold is the fraction of validators needed for reconstruction (typically 1/3).
+	// The minimum percentage of stake needed to cause a liveness failure.
+	LivenessThreshold cmtmath.Fraction
+
+	// Size constraints
+	//
+	// MaxBlobSize is the maximum allowed blob size in bytes (including any headers).
+	MaxBlobSize int
+	// MinRowSize is the minimum row size in bytes (rows are rounded up to this).
+	MinRowSize int
+}
+
+// DefaultProtocolParams contains the default protocol parameters for version 0.
+var DefaultProtocolParams = ProtocolParams{
+	// Erasure coding: 2^12 original rows, 3x parity (12288 parity rows, 16384 total)
+	Rows:          1 << 12,
+	EncodingRatio: 0.25,
+
+	// Network: 100 validators
+	MaxValidatorCount: 100,
+
+	// Security: 100 bits, 2/3 safety, 1/3 liveness
+	UniqueDecodingSecurityBits: 100,
+	SafetyThreshold:            cmtmath.Fraction{Numerator: 2, Denominator: 3},
+	LivenessThreshold:          cmtmath.Fraction{Numerator: 1, Denominator: 3},
+
+	// Size: 128 MiB max blob s(2^27), 64 byte minimum row size
+	MaxBlobSize: 1 << 27,
+	MinRowSize:  1 << 6,
+}
+
+func init() {
+	p := DefaultProtocolParams
+	livenessRatio := float64(p.LivenessThreshold.Numerator) / float64(p.LivenessThreshold.Denominator)
+	if livenessRatio < p.EncodingRatio {
+		panic("LivenessThreshold must always be bigger than EncodingRatio as we cannot disperse samples without overlap")
+	}
+}
+
+// TotalRows returns the total number of rows (K + N).
+func (p ProtocolParams) TotalRows() int {
+	return int(float64(p.Rows) / p.EncodingRatio)
+}
+
+// ParityRows returns the number of parity rows (N in rsema1d).
+func (p ProtocolParams) ParityRows() int {
+	return p.TotalRows() - p.Rows
+}
+
+// RowsPerShard returns the number of rows each shard receives.
+// This is the security-optimal number based on:
+//  1. Unique decode samples needed for cryptographic security
+//  2. Reconstruction samples needed for fault tolerance
+func (p ProtocolParams) RowsPerShard(totalShards int) int {
+	// Constraint 1: Unique decoding security
+	//
+	// The minimum number of samples s required for λ bits of security:
+	//
+	//              ⌈      λ          ⌉
+	//         s ≥  | ─────────────── |
+	//              ⌈ 1 - log₂(1 + ρ) ⌉
+	//
+	// Where:
+	//   λ (lambda) = UniqueDecodingSecurityBits
+	//   ρ (rho)    = EncodingRatio = K/(K+N)
+	//
+	uniqueDecodeSamples := int(math.Ceil(float64(p.UniqueDecodingSecurityBits) / (1 - math.Log2(1+p.EncodingRatio))))
+
+	// Constraint 2: Reconstruction samples for fault tolerance
+	// We need enough rows from LivenessThreshold fraction of shards to reconstruct
+	shardsForReconstruction := p.ShardsForReconstruction(totalShards)
+	reconstructionSamples := ceilDiv(p.Rows, shardsForReconstruction)
+
+	return max(uniqueDecodeSamples, reconstructionSamples)
+}
+
+// ShardsForReconstruction returns the minimum number of shards
+// needed to successfully reconstruct the original data.
+// Returns at least 1.
+func (p ProtocolParams) ShardsForReconstruction(totalShards int) int {
+	num := int(p.LivenessThreshold.Numerator)
+	den := int(p.LivenessThreshold.Denominator)
+	return max(1, ceilDiv(totalShards*num, den))
+}
+
+// RowSize computes the row size for the given blob version and total length.
+// Row size is calculated as ceil(totalLen / Rows), rounded up to MinRowSize.
+// Panics if the blob version is not supported.
+func (p ProtocolParams) RowSize(blobVersion uint8, totalLen int) int {
+	if blobVersion != 0 {
+		panic(fmt.Sprintf("unsupported blob version: %d", blobVersion))
+	}
+
+	if totalLen == 0 {
+		return 0
+	}
+
+	rowSize := ceilDiv(totalLen, p.Rows)
+
+	// Round up to nearest multiple of MinRowSize
+	if rowSize%p.MinRowSize != 0 {
+		rowSize = ((rowSize / p.MinRowSize) + 1) * p.MinRowSize
+	}
+
+	return rowSize
+}
+
+// MaxRowSize returns the maximum row size based on MaxBlobSize.
+func (p ProtocolParams) MaxRowSize(blobVersion uint8) int {
+	return p.RowSize(blobVersion, p.MaxBlobSize)
+}
+
+// MaxShardSize calculates the maximum size of a shard in bytes.
+// A shard contains: RLC coefficients + (rows_per_shard * (row_index + row_data + merkle_proof))
+func (p ProtocolParams) MaxShardSize(totalShards int) int {
+	const (
+		rowIndexSize = 4  // uint32 index per row
+		rlcCoeffSize = 16 // uint128 coefficient per row
+	)
+
+	totalRows := p.TotalRows()
+	maxRowSize := p.MaxRowSize(0) // version 0 is the only supported version
+	rlcCoeffsSize := p.Rows * rlcCoeffSize
+
+	// calculate merkle tree depth for inclusion proofs: ceil(log2(totalRows))
+	treeDepth := bits.Len(uint(totalRows - 1))
+	proofSizePerRow := treeDepth * sha256.Size
+
+	// rows per shard based on how Assign distributes total rows among shards
+	rowsPerShard := ceilDiv(totalRows, totalShards)
+	return rlcCoeffsSize + (rowsPerShard * (rowIndexSize + maxRowSize + proofSizePerRow))
+}
+
+// MaxMessageSize returns the maximum gRPC message size for upload requests.
+// Includes MaxShardSize, MaxPaymentPromiseSize, and 2% protobuf overhead.
+func (p ProtocolParams) MaxMessageSize(totalShards int) int {
+	msgSize := p.MaxShardSize(totalShards) + MaxPaymentPromiseSize
+	return msgSize + (msgSize / 50) // add 2% protobuf overhead
+}
+
+// ceilDiv returns ceil(a/b) using integer arithmetic.
+func ceilDiv(a, b int) int {
+	return (a + b - 1) / b
+}

--- a/fibre/protocol_params_test.go
+++ b/fibre/protocol_params_test.go
@@ -1,0 +1,77 @@
+package fibre
+
+import (
+	"testing"
+)
+
+func TestProtocolParams_RowSize(t *testing.T) {
+	tests := []struct {
+		name         string
+		totalLen     int // dataLen + headerLen
+		originalRows int
+		rowSizeMin   int
+		wantRowSize  int
+	}{
+		{
+			name:         "exact fit",
+			totalLen:     64 * 8, // Exactly fits in 8 rows of 64 bytes
+			originalRows: 8,
+			rowSizeMin:   64,
+			wantRowSize:  64,
+		},
+		{
+			name:         "needs rounding up",
+			totalLen:     100 + blobHeaderLen,
+			originalRows: 8,
+			rowSizeMin:   64,
+			wantRowSize:  64, // ceil(105/8) = 14, rounded up to 64
+		},
+		{
+			name:         "small data",
+			totalLen:     1 + blobHeaderLen,
+			originalRows: 8,
+			rowSizeMin:   64,
+			wantRowSize:  64, // ceil(6/8) = 1, rounded up to 64
+		},
+		{
+			name:         "large data",
+			totalLen:     10000 + blobHeaderLen,
+			originalRows: 8,
+			rowSizeMin:   64,
+			wantRowSize:  1280, // ceil(10005/8) = 1251, rounded up to 1280 (20*64)
+		},
+		{
+			name:         "different row size min",
+			totalLen:     1000 + blobHeaderLen,
+			originalRows: 4,
+			rowSizeMin:   128,
+			wantRowSize:  256, // ceil(1005/4) = 252, rounded up to 256 (2*128)
+		},
+		{
+			name:         "zero length",
+			totalLen:     0,
+			originalRows: 8,
+			rowSizeMin:   64,
+			wantRowSize:  0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := ProtocolParams{
+				Rows:       tt.originalRows,
+				MinRowSize: tt.rowSizeMin,
+			}
+
+			rowSize := p.RowSize(0, tt.totalLen)
+			if rowSize != tt.wantRowSize {
+				t.Errorf("RowSize(0, %d) = %d, want %d", tt.totalLen, rowSize, tt.wantRowSize)
+			}
+
+			// verify row size is multiple of MinRowSize (except for zero)
+			if rowSize != 0 && rowSize%tt.rowSizeMin != 0 {
+				t.Errorf("RowSize(%d) = %d, not a multiple of %d", tt.totalLen, rowSize, tt.rowSizeMin)
+			}
+		})
+	}
+}

--- a/fibre/server.go
+++ b/fibre/server.go
@@ -24,6 +24,9 @@ type ServerConfig struct {
 	BlobConfig
 	StoreConfig
 
+	// MaxMessageSize is the maximum gRPC message size for upload requests.
+	MaxMessageSize int
+
 	// Log is the logger for the server.
 	// If nil, slog.Default() will be used.
 	Log *slog.Logger
@@ -34,10 +37,17 @@ type ServerConfig struct {
 
 // DefaultServerConfig returns a [ServerConfig] with default values.
 func DefaultServerConfig() ServerConfig {
+	return NewServerConfigFromParams(DefaultProtocolParams)
+}
+
+// NewServerConfigFromParams creates a ServerConfig with values derived from the given ProtocolParams.
+// Use this when you need a config with non-default protocol parameters (e.g., for testing).
+func NewServerConfigFromParams(p ProtocolParams) ServerConfig {
 	return ServerConfig{
-		ChainID:     "celestia",
-		BlobConfig:  DefaultBlobConfigV0(),
-		StoreConfig: DefaultStoreConfig(),
+		ChainID:        "celestia",
+		BlobConfig:     DefaultBlobConfigV0(), // currently hardcode support for version zero only
+		StoreConfig:    DefaultStoreConfig(),
+		MaxMessageSize: p.MaxMessageSize(p.MaxValidatorCount),
 	}
 }
 

--- a/fibre/server_upload.go
+++ b/fibre/server_upload.go
@@ -197,9 +197,8 @@ func (s *Server) verifyShard(_ context.Context, promise *PaymentPromise, shard *
 		return fmt.Errorf("creating verification context: %w", err)
 	}
 
-	totalRows := s.cfg.OriginalRows + s.cfg.ParityRows
 	for _, rowPb := range shard.Rows {
-		row, err := parseRow(rowPb, totalRows)
+		row, err := parseRow(rowPb)
 		if err != nil {
 			return err
 		}
@@ -272,10 +271,7 @@ func parseRowSize(rows []*types.BlobRow) (int, error) {
 }
 
 // parseRow validates and converts a single proto row to rsema1d.RowProof format.
-func parseRow(row *types.BlobRow, totalRows int) (*rsema1d.RowProof, error) {
-	if int(row.Index) >= totalRows {
-		return nil, fmt.Errorf("row index %d out of bounds (total rows: %d)", row.Index, totalRows)
-	}
+func parseRow(row *types.BlobRow) (*rsema1d.RowProof, error) {
 	if len(row.Proof) == 0 {
 		return nil, fmt.Errorf("row %d missing proof", row.Index)
 	}

--- a/fibre/server_upload_test.go
+++ b/fibre/server_upload_test.go
@@ -188,7 +188,6 @@ func makeTestRequest(
 	t.Helper()
 
 	blob := makeTestBlobV0(t, 256*1024)
-	blobCfg := fibre.DefaultBlobConfigV0()
 	namespace := share.MustNewV0Namespace([]byte("testns"))
 
 	// create and sign payment promise
@@ -228,7 +227,7 @@ func makeTestRequest(
 	signPromise(promisePb)
 
 	// get row assignment for server validator
-	totalRows := blobCfg.OriginalRows + blobCfg.ParityRows
+	totalRows := blob.Config().OriginalRows + blob.Config().ParityRows
 	shardMap := valSet.Assign(rsema1d.Commitment(blob.Commitment()), totalRows)
 	rowIndices := shardMap[serverValidator]
 	require.NotEmpty(t, rowIndices, "server validator has no rows assigned")

--- a/multiplexer/abci/multiplexer.go
+++ b/multiplexer/abci/multiplexer.go
@@ -195,9 +195,8 @@ func (m *Multiplexer) enableGRPCAndAPIServers(app servertypes.Application) error
 			}
 			fibreServer.Start()
 
-			maxMsgSize := fibre.MaxMessageSize(serverConfig.BlobConfig)
-			m.svrCfg.GRPC.MaxRecvMsgSize = maxMsgSize
-			m.svrCfg.GRPC.MaxSendMsgSize = maxMsgSize
+			m.svrCfg.GRPC.MaxRecvMsgSize = serverConfig.MaxMessageSize
+			m.svrCfg.GRPC.MaxSendMsgSize = serverConfig.MaxMessageSize
 
 			// Add graceful shutdown for Fibre server
 			if fibreServer != nil {

--- a/tools/submit-fibre-blob/main.go
+++ b/tools/submit-fibre-blob/main.go
@@ -111,11 +111,12 @@ func main() {
 	queryClient := valaddrtypes.NewQueryClient(grpcConn)
 	hostReg := fibregrpc.NewHostRegistry(queryClient)
 
-	// Create Fibre client config
-	clientCfg := fibre.DefaultClientConfig()
+	// Create Fibre client config for single node testnet
+	params := fibre.DefaultProtocolParams
+	params.MaxValidatorCount = 1 // Single node testnet
+	clientCfg := fibre.NewClientConfigFromParams(params)
 	clientCfg.ChainID = *chainID
 	clientCfg.DefaultKeyName = *keyName
-	clientCfg.ShardingFactor = 1 // This is a single node testnet
 
 	// Create Fibre client
 	fibreClient, err := fibre.NewClient(txClient, kr, valGet, hostReg, clientCfg)


### PR DESCRIPTION
The premise behind this change started from work on https://github.com/celestiaorg/celestia-app-fibre/issues/80. The current parameter configuration was overloaded and convoluted, and more dynamic and static configurations were about to be added for #80, which together called for a cleanup. 

In the end, in this PR, existing protocol parameters are extracted, and new ones are added into a separate new ProtocolParams struct that defines fundamental protocol constants from which other parameters are calculated and used in the respective blob, client, and server configs.

Besides, a MaxBlobSize check bug was fixed, in which the blob header overhead was not taken into account, and the first steps towards blob versioning were taken.

The newly added and existing parameters were audited with @nashqueue.