### PR TITLE
feat(fibre/validator): stake-based assign

### DIFF
--- a/fibre/blob.go
+++ b/fibre/blob.go
@@ -91,6 +91,11 @@ func NewBlobConfigFromParams(blobVersion uint8, p ProtocolParams) BlobConfig {
 	}
 }
 
+// TotalRows returns the total number of rows (OriginalRows + ParityRows).
+func (c BlobConfig) TotalRows() int {
+	return c.OriginalRows + c.ParityRows
+}
+
 // UploadSize calculates size of blob data with padding and w/o parity.
 // This is the size included in the [PaymentPromise] and the one actually paid for.
 func (c BlobConfig) UploadSize(dataLen int) int {

--- a/fibre/client.go
+++ b/fibre/client.go
@@ -35,13 +35,16 @@ type ClientConfig struct {
 	// ChainID is the chain identifier for domain separation in [PaymentPromise] signatures.
 	ChainID string
 
-	// RowsPerShard computes the number of rows per shard given the total number of shards.
-	RowsPerShard func(totalShards int) int
+	// SafetyThreshold is the fraction of stake needed to cause a safety failure (typically 2/3).
+	SafetyThreshold cmtmath.Fraction
+	// LivenessThreshold is the fraction of stake needed to cause a liveness failure (typically 1/3).
+	LivenessThreshold cmtmath.Fraction
+	// MinRowsPerValidator is the minimum number of rows each validator must receive
+	// for unique decodability security.
+	MinRowsPerValidator int
 	// MaxMessageSize is the maximum gRPC message size for upload requests.
 	MaxMessageSize int
 
-	// UploadTargetVotingPower is the fraction (e.g., 2/3) of total voting power required for Upload operations.
-	UploadTargetVotingPower cmtmath.Fraction
 	// UploadTargetSignaturesCount is the fraction (e.g., 2/3) of total signature count required for Upload operations.
 	UploadTargetSignaturesCount cmtmath.Fraction
 
@@ -76,12 +79,13 @@ func NewClientConfigFromParams(p ProtocolParams) ClientConfig {
 	return ClientConfig{
 		DefaultKeyName:              DefaultKeyName,
 		ChainID:                     "celestia",
-		RowsPerShard:                p.RowsPerShard,
-		MaxMessageSize:              p.MaxMessageSize(p.MaxValidatorCount),
-		UploadTargetVotingPower:     p.SafetyThreshold,
+		SafetyThreshold:             p.SafetyThreshold,
+		LivenessThreshold:           p.LivenessThreshold,
+		MinRowsPerValidator:         p.MinRowsPerValidator(),
+		MaxMessageSize:              p.MaxMessageSize(),
 		UploadTargetSignaturesCount: p.SafetyThreshold,
 		UploadConcurrency:           p.MaxValidatorCount,
-		DownloadConcurrency:         p.ShardsForReconstruction(p.MaxValidatorCount),
+		DownloadConcurrency:         p.ValidatorsForReconstruction(),
 	}
 }
 

--- a/fibre/client_upload.go
+++ b/fibre/client_upload.go
@@ -67,7 +67,7 @@ func (c *Client) Upload(ctx context.Context, ns share.Namespace, blob *Blob) (re
 	))
 
 	// 2) assign shards to validators
-	shardMap := valSet.Assign(rsema1d.Commitment(blob.Commitment()), c.cfg.RowsPerShard(len(valSet.Validators)))
+	shardMap := valSet.Assign(rsema1d.Commitment(blob.Commitment()), blob.Config().TotalRows(), blob.Config().OriginalRows, c.cfg.MinRowsPerValidator, c.cfg.LivenessThreshold)
 	span.AddEvent("shards_assigned")
 
 	validatorSignBytes, err := promise.SignBytesValidator()
@@ -78,7 +78,7 @@ func (c *Client) Upload(ctx context.Context, ns share.Namespace, blob *Blob) (re
 	}
 
 	requests := makeUploadRequests(shardMap, promise.ToProto(), blob.RLCCoeffs())
-	sigSet := valSet.NewSignatureSet(c.cfg.UploadTargetVotingPower, c.cfg.UploadTargetSignaturesCount, validatorSignBytes)
+	sigSet := valSet.NewSignatureSet(c.cfg.SafetyThreshold, c.cfg.UploadTargetSignaturesCount, validatorSignBytes)
 
 	c.log.DebugContext(ctx, "initiating blob upload",
 		"promise_hash", hex.EncodeToString(promiseHash),

--- a/fibre/client_upload_test.go
+++ b/fibre/client_upload_test.go
@@ -159,7 +159,7 @@ func testClientUploadInsufficientSignaturesCount(t *testing.T) {
 	// Fail 35 validators to get 65 signatures (< 66 required for 2/3)
 	// Set low voting power threshold (1/3) so power passes, but high signature count threshold (2/3) so count fails
 	client := makeTestClientWithFailures(t, numValidators, 35, func(cfg *fibre.ClientConfig) {
-		cfg.UploadTargetVotingPower = cmtmath.Fraction{Numerator: 1, Denominator: 3}     // Low threshold (34 signatures) - will pass
+		cfg.SafetyThreshold = cmtmath.Fraction{Numerator: 1, Denominator: 3}             // Low threshold (34 signatures) - will pass
 		cfg.UploadTargetSignaturesCount = cmtmath.Fraction{Numerator: 2, Denominator: 3} // High threshold (66 signatures) - will fail
 	})
 	defer client.Close()
@@ -257,7 +257,7 @@ func makeTestClientWithFailures(t *testing.T, numValidators, numFailures int, cu
 	cfg := fibre.DefaultClientConfig()
 	cfg.NewClientFn = mockClientFn
 	cfg.UploadConcurrency = 10 // Set lower than numValidators to ensure semaphore limits concurrency
-	cfg.UploadTargetVotingPower = cmtmath.Fraction{Numerator: 2, Denominator: 3}
+	cfg.SafetyThreshold = cmtmath.Fraction{Numerator: 2, Denominator: 3}
 	cfg.UploadTargetSignaturesCount = cmtmath.Fraction{Numerator: 0, Denominator: 1}
 	if customCfg != nil {
 		customCfg(&cfg)

--- a/fibre/protocol_params.go
+++ b/fibre/protocol_params.go
@@ -86,11 +86,30 @@ func (p ProtocolParams) ParityRows() int {
 	return p.TotalRows() - p.Rows
 }
 
-// RowsPerShard returns the number of rows each shard receives.
+// MaxRowsPerValidator returns the maximum number of rows a single validator could receive.
+// Based on max stake of 1-SafetyThreshold: ceil(Rows * (1-SafetyThreshold) / livenessThreshold).
+// Validators with >1-SafetyThreshold stake are capped at Rows in Assign.
+// Simplifies to 4096 given current default.
+func (p ProtocolParams) MaxRowsPerValidator() int {
+	// maxStake = 1 - SafetyThreshold = (denominator - numerator) / denominator
+	maxStakeNum := int(p.SafetyThreshold.Denominator - p.SafetyThreshold.Numerator)
+	maxStakeDen := int(p.SafetyThreshold.Denominator)
+
+	// rows = ceil(Rows * maxStake / livenessThreshold)
+	//      = ceil(Rows * maxStakeNum * livenessDen / (maxStakeDen * livenessNum))
+	num := p.Rows * maxStakeNum * int(p.LivenessThreshold.Denominator)
+	den := maxStakeDen * int(p.LivenessThreshold.Numerator)
+	return ceilDiv(num, den)
+}
+
+// MinRowsPerValidator returns the minimum number of rows each validator must receive
+// for unique decodability security, regardless of their stake percentage.
 // This is the security-optimal number based on:
 //  1. Unique decode samples needed for cryptographic security
 //  2. Reconstruction samples needed for fault tolerance
-func (p ProtocolParams) RowsPerShard(totalShards int) int {
+//
+// Uses MaxValidatorCount to compute a conservative (safe) minimum.
+func (p ProtocolParams) MinRowsPerValidator() int {
 	// Constraint 1: Unique decoding security
 	//
 	// The minimum number of samples s required for λ bits of security:
@@ -106,20 +125,22 @@ func (p ProtocolParams) RowsPerShard(totalShards int) int {
 	uniqueDecodeSamples := int(math.Ceil(float64(p.UniqueDecodingSecurityBits) / (1 - math.Log2(1+p.EncodingRatio))))
 
 	// Constraint 2: Reconstruction samples for fault tolerance
-	// We need enough rows from LivenessThreshold fraction of shards to reconstruct
-	shardsForReconstruction := p.ShardsForReconstruction(totalShards)
-	reconstructionSamples := ceilDiv(p.Rows, shardsForReconstruction)
+	// We need enough rows from LivenessThreshold fraction of validators to reconstruct
+	num := int(p.LivenessThreshold.Numerator)
+	den := int(p.LivenessThreshold.Denominator)
+	validatorsForReconstruction := max(1, ceilDiv(p.MaxValidatorCount*num, den))
+	reconstructionSamples := ceilDiv(p.Rows, validatorsForReconstruction)
 
 	return max(uniqueDecodeSamples, reconstructionSamples)
 }
 
-// ShardsForReconstruction returns the minimum number of shards
+// ValidatorsForReconstruction returns the minimum number of validators
 // needed to successfully reconstruct the original data.
-// Returns at least 1.
-func (p ProtocolParams) ShardsForReconstruction(totalShards int) int {
+// Uses MaxValidatorCount and returns at least 1.
+func (p ProtocolParams) ValidatorsForReconstruction() int {
 	num := int(p.LivenessThreshold.Numerator)
 	den := int(p.LivenessThreshold.Denominator)
-	return max(1, ceilDiv(totalShards*num, den))
+	return max(1, ceilDiv(p.MaxValidatorCount*num, den))
 }
 
 // RowSize computes the row size for the given blob version and total length.
@@ -150,8 +171,8 @@ func (p ProtocolParams) MaxRowSize(blobVersion uint8) int {
 }
 
 // MaxShardSize calculates the maximum size of a shard in bytes.
-// A shard contains: RLC coefficients + (rows_per_shard * (row_index + row_data + merkle_proof))
-func (p ProtocolParams) MaxShardSize(totalShards int) int {
+// A shard contains: RLC coefficients + (rows_per_validator * (row_index + row_data + merkle_proof))
+func (p ProtocolParams) MaxShardSize() int {
 	const (
 		rowIndexSize = 4  // uint32 index per row
 		rlcCoeffSize = 16 // uint128 coefficient per row
@@ -165,14 +186,13 @@ func (p ProtocolParams) MaxShardSize(totalShards int) int {
 	treeDepth := bits.Len(uint(totalRows - 1))
 	proofSizePerRow := treeDepth * sha256.Size
 
-	rowsPerShard := p.RowsPerShard(totalShards)
-	return rlcCoeffsSize + (rowsPerShard * (rowIndexSize + maxRowSize + proofSizePerRow))
+	return rlcCoeffsSize + (p.MaxRowsPerValidator() * (rowIndexSize + maxRowSize + proofSizePerRow))
 }
 
 // MaxMessageSize returns the maximum gRPC message size for upload requests.
 // Includes MaxShardSize, MaxPaymentPromiseSize, and 2% protobuf overhead.
-func (p ProtocolParams) MaxMessageSize(totalShards int) int {
-	msgSize := p.MaxShardSize(totalShards) + MaxPaymentPromiseSize
+func (p ProtocolParams) MaxMessageSize() int {
+	msgSize := p.MaxShardSize() + MaxPaymentPromiseSize
 	return msgSize + (msgSize / 50) // add 2% protobuf overhead
 }
 

--- a/fibre/server.go
+++ b/fibre/server.go
@@ -9,6 +9,7 @@ import (
 	"github.com/celestiaorg/celestia-app/v6/fibre/validator"
 	"github.com/celestiaorg/celestia-app/v6/x/fibre/types"
 	"github.com/cometbft/cometbft/crypto"
+	cmtmath "github.com/cometbft/cometbft/libs/math"
 	coregrpc "github.com/cometbft/cometbft/rpc/grpc"
 	core "github.com/cometbft/cometbft/types"
 	"github.com/cosmos/gogoproto/grpc"
@@ -24,8 +25,11 @@ type ServerConfig struct {
 	BlobConfig
 	StoreConfig
 
-	// RowsPerShard computes the number of rows per shard given the total number of shards.
-	RowsPerShard func(totalShards int) int
+	// LivenessThreshold is the fraction of stake needed for reconstruction (typically 1/3).
+	LivenessThreshold cmtmath.Fraction
+	// MinRowsPerValidator is the minimum number of rows each validator must receive
+	// for unique decodability security.
+	MinRowsPerValidator int
 	// MaxMessageSize is the maximum gRPC message size for upload requests.
 	MaxMessageSize int
 
@@ -46,11 +50,12 @@ func DefaultServerConfig() ServerConfig {
 // Use this when you need a config with non-default protocol parameters (e.g., for testing).
 func NewServerConfigFromParams(p ProtocolParams) ServerConfig {
 	return ServerConfig{
-		ChainID:        "celestia",
-		BlobConfig:     DefaultBlobConfigV0(), // currently hardcode support for version zero only
-		StoreConfig:    DefaultStoreConfig(),
-		RowsPerShard:   p.RowsPerShard,
-		MaxMessageSize: p.MaxMessageSize(p.MaxValidatorCount),
+		ChainID:             "celestia",
+		BlobConfig:          DefaultBlobConfigV0(), // currently hardcode support for version zero only
+		StoreConfig:         DefaultStoreConfig(),
+		LivenessThreshold:   p.LivenessThreshold,
+		MinRowsPerValidator: p.MinRowsPerValidator(),
+		MaxMessageSize:      p.MaxMessageSize(),
 	}
 }
 

--- a/fibre/server_upload.go
+++ b/fibre/server_upload.go
@@ -157,7 +157,7 @@ func (s *Server) verifyAssignment(ctx context.Context, promise *PaymentPromise, 
 	for i, row := range shard.GetRows() {
 		rowIndices[i] = row.Index
 	}
-	shardMap := valSet.Assign(rsema1d.Commitment(promise.Commitment), s.cfg.RowsPerShard(len(valSet.Validators)))
+	shardMap := valSet.Assign(rsema1d.Commitment(promise.Commitment), s.cfg.TotalRows(), s.cfg.OriginalRows, s.cfg.MinRowsPerValidator, s.cfg.LivenessThreshold)
 	if err := shardMap.Verify(ourValidator, rowIndices); err != nil {
 		return err
 	}

--- a/fibre/server_upload_test.go
+++ b/fibre/server_upload_test.go
@@ -84,7 +84,7 @@ func TestServerUploadShard(t *testing.T) {
 				// get commitment from the request (it's already a byte slice)
 				var commitment rsema1d.Commitment
 				copy(commitment[:], req.Promise.Commitment)
-				shardMap := valSet.Assign(commitment, cfg.RowsPerShard(len(valSet.Validators)))
+				shardMap := valSet.Assign(commitment, cfg.TotalRows(), cfg.OriginalRows, cfg.MinRowsPerValidator, cfg.LivenessThreshold)
 				for val, indices := range shardMap {
 					if val.Address.String() != serverValidator.Address.String() && len(indices) > 0 {
 						req.Shard.Rows[0].Index = uint32(indices[0])
@@ -227,7 +227,8 @@ func makeTestRequest(
 	signPromise(promisePb)
 
 	// get row assignment for server validator
-	shardMap := valSet.Assign(rsema1d.Commitment(blob.Commitment()), fibre.DefaultProtocolParams.RowsPerShard(len(valSet.Validators)))
+	cfg := fibre.DefaultServerConfig()
+	shardMap := valSet.Assign(rsema1d.Commitment(blob.Commitment()), cfg.TotalRows(), cfg.OriginalRows, cfg.MinRowsPerValidator, cfg.LivenessThreshold)
 	rowIndices := shardMap[serverValidator]
 	require.NotEmpty(t, rowIndices, "server validator has no rows assigned")
 

--- a/fibre/validator/set.go
+++ b/fibre/validator/set.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/celestiaorg/rsema1d"
 	"github.com/cometbft/cometbft/crypto"
+	cmtmath "github.com/cometbft/cometbft/libs/math"
 	core "github.com/cometbft/cometbft/types"
 )
 
@@ -33,17 +34,35 @@ type ShardMap map[*core.Validator][]int
 // Assign returns a ShardMap containing all validators and their assigned row indices
 // for the given commitment.
 //
-// The rowsPerValidator parameter specifies how many rows each validator receives.
-// Total rows distributed = rowsPerValidator * len(validators).
+// Rows are distributed based on the relation: originalRows / rows = livenessThreshold / stake%
+// This means 33% stake should have originalRows (4096), so each validator gets:
+// rows = ceil(originalRows * stake% / livenessThreshold)
 //
-// It uses a chacha8 RNG with the commitment as the seed to shuffle the row indices
-// using the Fisher-Yates algorithm.
-func (s Set) Assign(commitment rsema1d.Commitment, rowsPerValidator int) ShardMap {
-	if len(s.Validators) == 0 || rowsPerValidator == 0 {
+// The minRows parameter ensures every validator receives at least that many rows
+// for unique decodability security, even if their proportional share would be less.
+//
+// When the sum of assigned rows exceeds totalRows (due to minRows floor guarantees),
+// row indices wrap around using modulo arithmetic. This means the same row may be
+// assigned to multiple validators, ensuring all validators receive their required
+// minimum while maintaining deterministic assignment.
+//
+// It uses a ChaCha8 RNG seeded with the commitment to shuffle the row indices
+// using the Fisher-Yates algorithm, ensuring deterministic and uniform distribution.
+func (s Set) Assign(commitment rsema1d.Commitment, totalRows, originalRows, minRows int, livenessThreshold cmtmath.Fraction) ShardMap {
+	if len(s.Validators) == 0 || totalRows == 0 || minRows == 0 {
 		return make(ShardMap)
 	}
 
-	totalRows := rowsPerValidator * len(s.Validators)
+	// rows = ceil(originalRows * stake% / livenessThreshold)
+	//      = ceil(originalRows * votingPower * denominator / (totalVotingPower * numerator))
+	// Capped at originalRows since that's all needed for reconstruction.
+	rowsPerValidator := make([]int, len(s.Validators))
+	for i, v := range s.Validators {
+		num := int64(originalRows) * v.VotingPower * int64(livenessThreshold.Denominator)
+		den := s.TotalVotingPower() * int64(livenessThreshold.Numerator)
+		rows := int((num + den - 1) / den) // ceil division
+		rowsPerValidator[i] = min(max(rows, minRows), originalRows)
+	}
 
 	var seed [32]byte
 	copy(seed[:], commitment[:])
@@ -51,7 +70,7 @@ func (s Set) Assign(commitment rsema1d.Commitment, rowsPerValidator int) ShardMa
 	// chacha8 RNG with seed being the commitment
 	rng := rand.New(rand.NewChaCha8(seed))
 
-	// shuffle row indices with Fisher-Yates algorithm
+	// shuffle all totalRows indices with Fisher-Yates algorithm
 	// NOTE: std library Shuffle implements Fisher-Yates algorithm
 	rowsIndicies := make([]int, totalRows)
 	for i := range totalRows {
@@ -61,11 +80,17 @@ func (s Set) Assign(commitment rsema1d.Commitment, rowsPerValidator int) ShardMa
 		rowsIndicies[i], rowsIndicies[j] = rowsIndicies[j], rowsIndicies[i]
 	})
 
-	// assign rows to validators in a ShardMap
+	// assign rows to validators, wrapping around with modulo if total assigned exceeds totalRows
 	shardMap := make(ShardMap)
+	offset := 0
 	for i, validator := range s.Validators {
-		offset := i * rowsPerValidator
-		shardMap[validator] = rowsIndicies[offset : offset+rowsPerValidator]
+		rows := make([]int, rowsPerValidator[i])
+		for j := range rows {
+			// modulo ensures wrap-around when minRows causes over-assignment
+			rows[j] = rowsIndicies[(offset+j)%totalRows]
+		}
+		shardMap[validator] = rows
+		offset += rowsPerValidator[i]
 	}
 
 	return shardMap

--- a/fibre/validator/set_test.go
+++ b/fibre/validator/set_test.go
@@ -7,9 +7,13 @@ import (
 	"github.com/celestiaorg/celestia-app/v6/fibre/validator"
 	"github.com/celestiaorg/rsema1d"
 	"github.com/cometbft/cometbft/crypto/ed25519"
+	cmtmath "github.com/cometbft/cometbft/libs/math"
 	core "github.com/cometbft/cometbft/types"
 	"github.com/stretchr/testify/require"
 )
+
+// default liveness threshold for tests (1/3)
+var testLivenessThreshold = cmtmath.Fraction{Numerator: 1, Denominator: 3}
 
 func TestSet_Assign(t *testing.T) {
 	commitment := rsema1d.Commitment{
@@ -20,15 +24,23 @@ func TestSet_Assign(t *testing.T) {
 	t.Run("EmptySet", func(t *testing.T) {
 		valSet := makeValidatorSet(0)
 
-		shardMap := valSet.Assign(commitment, 5)
+		shardMap := valSet.Assign(commitment, 100, 25, 10, testLivenessThreshold)
 		require.NotNil(t, shardMap)
 		require.Empty(t, shardMap)
 	})
 
-	t.Run("ZeroRowsPerValidator", func(t *testing.T) {
+	t.Run("ZeroTotalRows", func(t *testing.T) {
 		valSet := makeValidatorSet(3)
 
-		shardMap := valSet.Assign(commitment, 0)
+		shardMap := valSet.Assign(commitment, 0, 0, 10, testLivenessThreshold)
+		require.NotNil(t, shardMap)
+		require.Empty(t, shardMap)
+	})
+
+	t.Run("ZeroMinRows", func(t *testing.T) {
+		valSet := makeValidatorSet(3)
+
+		shardMap := valSet.Assign(commitment, 100, 25, 0, testLivenessThreshold)
 		require.NotNil(t, shardMap)
 		require.Empty(t, shardMap)
 	})
@@ -36,22 +48,22 @@ func TestSet_Assign(t *testing.T) {
 	t.Run("SingleValidator", func(t *testing.T) {
 		valSet := makeValidatorSet(1)
 
-		rowsPerValidator := 10
-		shardMap := valSet.Assign(commitment, rowsPerValidator)
+		// Single validator with 100% stake would get ceil(originalRows * 1.0 / (1/3)) = originalRows * 3 rows
+		// But capped at originalRows since that's all needed for reconstruction
+		totalRows := 30
+		originalRows := 10
+		shardMap := valSet.Assign(commitment, totalRows, originalRows, 1, testLivenessThreshold)
 		require.NotNil(t, shardMap)
 		require.Len(t, shardMap, 1)
 
-		// All rows should be assigned to the single validator
+		// Single validator gets capped at originalRows
 		for _, rows := range shardMap {
-			require.Len(t, rows, rowsPerValidator)
-			// Verify all row indices are present
-			for i := range rowsPerValidator {
-				require.Contains(t, rows, i)
-			}
+			require.Len(t, rows, originalRows)
 		}
 	})
 
-	t.Run("Distribution", func(t *testing.T) {
+	t.Run("EqualStakesDistribution", func(t *testing.T) {
+		// Test with equal stakes - all validators should get equal rows
 		valSet := makeValidatorSet(100)
 
 		hasher := sha256.New()
@@ -59,13 +71,18 @@ func TestSet_Assign(t *testing.T) {
 		var distCommitment rsema1d.Commitment
 		copy(distCommitment[:], hasher.Sum(nil))
 
-		rowsPerValidator := 163
-		shardMap := valSet.Assign(distCommitment, rowsPerValidator)
+		// With 100 validators each having 1% stake and livenessThreshold=1/3:
+		// rows = ceil(originalRows * 0.01 / (1/3)) = ceil(originalRows * 0.03)
+		// For originalRows=1000, each gets ceil(30) = 30 rows, total = 3000
+		totalRows := 3000
+		originalRows := 1000
+		minRows := 1 // low minRows so proportional distribution dominates
+		expectedRowsPerValidator := 30
+		shardMap := valSet.Assign(distCommitment, totalRows, originalRows, minRows, testLivenessThreshold)
 
 		require.Len(t, shardMap, len(valSet.Validators), "All validators should be in shard map")
 
 		totalAssigned := 0
-		totalRows := rowsPerValidator * len(valSet.Validators)
 
 		// Track all assigned rows globally to detect cross-validator duplicates
 		globalSeen := make(map[int]bool)
@@ -74,28 +91,119 @@ func TestSet_Assign(t *testing.T) {
 			count := len(rows)
 			totalAssigned += count
 
-			// Each validator gets exactly rowsPerValidator rows
-			require.Equal(t, rowsPerValidator, count, "validator %s should have exactly %d rows", val.Address, rowsPerValidator)
+			// With equal stakes, each validator gets exactly expectedRowsPerValidator rows
+			require.Equal(t, expectedRowsPerValidator, count, "validator %s should have exactly %d rows", val.Address, expectedRowsPerValidator)
 
 			// Verify row indices are unique (within validator and across all validators) and in range
 			for _, rowIdx := range rows {
 				require.False(t, globalSeen[rowIdx], "duplicate row index %d across validators", rowIdx)
 				require.GreaterOrEqual(t, rowIdx, 0)
-				require.Less(t, rowIdx, totalRows)
 				globalSeen[rowIdx] = true
 			}
 		}
 
 		require.Equal(t, totalRows, totalAssigned, "All rows should be assigned")
-		t.Logf("Total assigned: %d (rowsPerValidator=%d, validators=%d)", totalAssigned, rowsPerValidator, len(valSet.Validators))
+		t.Logf("Total assigned: %d (rowsPerValidator=%d, validators=%d)", totalAssigned, expectedRowsPerValidator, len(valSet.Validators))
+	})
+
+	t.Run("StakeProportionalDistribution", func(t *testing.T) {
+		// Create validators with different stakes: 1, 2, 3 (total = 6)
+		valSet := makeValidatorSetWithStakes([]int64{1, 2, 3})
+
+		hasher := sha256.New()
+		hasher.Write([]byte("stake-proportional-test"))
+		var distCommitment rsema1d.Commitment
+		copy(distCommitment[:], hasher.Sum(nil))
+
+		// With stakes 1,2,3 (total=6) and livenessThreshold=1/3:
+		// rows = min(ceil(originalRows * stake * 3 / totalStake), originalRows)
+		// For originalRows=18: stake1 gets min(ceil(18*1*3/6),18)=9, stake2 gets min(ceil(18*2*3/6),18)=18, stake3 gets min(ceil(18*3*3/6),18)=18
+		// Use larger originalRows so cap doesn't affect smaller stakes
+		totalRows := 54
+		originalRows := 18
+		minRows := 1 // low minRows so proportional distribution dominates
+		shardMap := valSet.Assign(distCommitment, totalRows, originalRows, minRows, testLivenessThreshold)
+
+		require.Len(t, shardMap, 3, "All validators should be in shard map")
+
+		totalAssigned := 0
+		globalSeen := make(map[int]bool)
+
+		for val, rows := range shardMap {
+			count := len(rows)
+			totalAssigned += count
+
+			// rows = min(ceil(originalRows * votingPower * 3 / totalStake), originalRows)
+			formulaRows := int((int64(originalRows)*val.VotingPower*3 + 5) / 6) // ceil division
+			expectedRows := min(formulaRows, originalRows)                      // cap at originalRows
+			require.Equal(t, expectedRows, count, "validator with stake %d should have %d rows, got %d",
+				val.VotingPower, expectedRows, count)
+
+			for _, rowIdx := range rows {
+				require.False(t, globalSeen[rowIdx], "duplicate row index %d across validators", rowIdx)
+				require.GreaterOrEqual(t, rowIdx, 0)
+				globalSeen[rowIdx] = true
+			}
+		}
+
+		t.Logf("Total assigned: %d (totalRows=%d, stakes=1,2,3)", totalAssigned, totalRows)
+	})
+
+	t.Run("MinRowsFloor", func(t *testing.T) {
+		// Create validators with different stakes: 1, 2, 3 (total = 6)
+		// With small stakes, formula would give small values for low-stake validators
+		// But minRows should ensure everyone gets at least minRows
+		// Note: minRows must be <= originalRows
+		valSet := makeValidatorSetWithStakes([]int64{1, 2, 3})
+
+		hasher := sha256.New()
+		hasher.Write([]byte("minrows-floor-test"))
+		var distCommitment rsema1d.Commitment
+		copy(distCommitment[:], hasher.Sum(nil))
+
+		// With stakes 1,2,3 (total=6) and livenessThreshold=1/3:
+		// Formula: rows = ceil(originalRows * stake * 3 / totalStake)
+		// stake1: ceil(6*1*3/6) = 3 -> but minRows=5 floors it to 5
+		// stake2: ceil(6*2*3/6) = 6 -> capped at originalRows=6
+		// stake3: ceil(6*3*3/6) = 9 -> capped at originalRows=6
+		// Total = 5+6+6 = 17 rows, with wrap-around since totalRows=18
+		totalRows := 18
+		originalRows := 6
+		minRows := 5 // must be <= originalRows
+		shardMap := valSet.Assign(distCommitment, totalRows, originalRows, minRows, testLivenessThreshold)
+
+		require.Len(t, shardMap, 3, "All validators should be in shard map")
+
+		totalAssigned := 0
+
+		for val, rows := range shardMap {
+			count := len(rows)
+			totalAssigned += count
+
+			// Every validator should get at least minRows (capped at originalRows)
+			require.GreaterOrEqual(t, count, minRows, "validator with stake %d should have at least %d rows, got %d",
+				val.VotingPower, minRows, count)
+			require.LessOrEqual(t, count, originalRows, "validator with stake %d should have at most %d rows, got %d",
+				val.VotingPower, originalRows, count)
+
+			// All row indices should be within [0, totalRows)
+			for _, rowIdx := range rows {
+				require.GreaterOrEqual(t, rowIdx, 0)
+				require.Less(t, rowIdx, totalRows, "row index %d should be less than totalRows %d", rowIdx, totalRows)
+			}
+		}
+
+		t.Logf("Total assigned: %d (totalRows=%d, minRows=%d, originalRows=%d, stakes=1,2,3)", totalAssigned, totalRows, minRows, originalRows)
 	})
 
 	t.Run("Determinism", func(t *testing.T) {
 		valSet := makeValidatorSet(3)
 
-		rowsPerValidator := 17
-		firstRun := valSet.Assign(commitment, rowsPerValidator)
-		secondRun := valSet.Assign(commitment, rowsPerValidator)
+		totalRows := 51
+		originalRows := 17
+		minRows := 5
+		firstRun := valSet.Assign(commitment, totalRows, originalRows, minRows, testLivenessThreshold)
+		secondRun := valSet.Assign(commitment, totalRows, originalRows, minRows, testLivenessThreshold)
 
 		require.Len(t, firstRun, len(secondRun))
 
@@ -122,7 +230,10 @@ func BenchmarkSet_Assign(b *testing.B) {
 		17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32,
 	}
 
-	rowsPerValidator := 164 // typical value for 100 validators
+	totalRows := 16384   // typical total rows
+	originalRows := 4096 // typical original rows
+	minRows := 16        // typical minimum rows per validator
+	livenessThreshold := cmtmath.Fraction{Numerator: 1, Denominator: 3}
 
 	benchmarks := []struct {
 		name          string
@@ -137,7 +248,7 @@ func BenchmarkSet_Assign(b *testing.B) {
 		b.Run(bm.name, func(b *testing.B) {
 			valSet := makeValidatorSet(bm.numValidators)
 			for b.Loop() {
-				_ = valSet.Assign(commitment, rowsPerValidator)
+				_ = valSet.Assign(commitment, totalRows, originalRows, minRows, livenessThreshold)
 			}
 		})
 	}
@@ -149,7 +260,9 @@ func TestShardMap_Verify(t *testing.T) {
 		17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32,
 	}
 	valSet := makeValidatorSet(3)
-	shardMap := valSet.Assign(commitment, 4) // 4 rows per validator
+	// 3 validators with equal stake (1/3 each), livenessThreshold=1/3
+	// rows = ceil(4 * (1/3) * 3) = 4 per validator, total = 12
+	shardMap := valSet.Assign(commitment, 12, 4, 1, testLivenessThreshold)
 
 	// test valid assignments
 	for val, rows := range shardMap {
@@ -207,6 +320,18 @@ func makeValidatorSet(n int) validator.Set {
 	for i := range n {
 		privKey := ed25519.GenPrivKey()
 		validators[i] = core.NewValidator(privKey.PubKey(), 1)
+	}
+	return validator.Set{
+		ValidatorSet: core.NewValidatorSet(validators),
+		Height:       100,
+	}
+}
+
+func makeValidatorSetWithStakes(stakes []int64) validator.Set {
+	validators := make([]*core.Validator, len(stakes))
+	for i, stake := range stakes {
+		privKey := ed25519.GenPrivKey()
+		validators[i] = core.NewValidator(privKey.PubKey(), stake)
 	}
 	return validator.Set{
 		ValidatorSet: core.NewValidatorSet(validators),


### PR DESCRIPTION
Notably had to also change the MaxMessageSize calculation and bring in another assumption that no validator can have more than 1-SafetyThreshold power as stake power ceiling for row distribution for a validator. 

Depends on #146 
Closes #144 