### PR TITLE
fix(standalone): use SDK genesis provider to handle AppGenesis format

### DIFF
--- a/cmd/celestia-appd/cmd/start_command_standalone.go
+++ b/cmd/celestia-appd/cmd/start_command_standalone.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cometbft/cometbft/proxy"
 	"github.com/cometbft/cometbft/rpc/client/local"
 	coregrpc "github.com/cometbft/cometbft/rpc/grpc"
+	cmttypes "github.com/cometbft/cometbft/types"
 	db "github.com/cosmos/cosmos-db"
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/server"
@@ -28,6 +29,7 @@ import (
 	servercmtlog "github.com/cosmos/cosmos-sdk/server/log"
 	servertypes "github.com/cosmos/cosmos-sdk/server/types"
 	"github.com/cosmos/cosmos-sdk/telemetry"
+	genutiltypes "github.com/cosmos/cosmos-sdk/x/genutil/types"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
@@ -173,7 +175,7 @@ func startCometNode(svrCtx *server.Context, appInstance servertypes.Application)
 		privVal,
 		nodeKey,
 		proxy.NewLocalClientCreator(cmtApp),
-		node.DefaultGenesisDocProviderFunc(cfg),
+		getGenDocProvider(cfg),
 		cmtcfg.DefaultDBProvider,
 		node.DefaultMetricsProvider(cfg.Instrumentation),
 		servercmtlog.CometLoggerWrapper{Logger: svrCtx.Logger},
@@ -340,4 +342,17 @@ func openTraceWriter(traceWriterFile string) (io.WriteCloser, error) {
 func openDB(rootDir string, backendType db.BackendType) (db.DB, error) {
 	dataDir := filepath.Join(rootDir, "data")
 	return db.NewDB("application", backendType, dataDir)
+}
+
+// getGenDocProvider returns a function that loads the genesis document from file.
+// This uses the SDK's AppGenesis format and converts it to CometBFT's GenesisDoc,
+// which properly handles the type conversion (e.g., InitialHeight as int64 vs string).
+func getGenDocProvider(cfg *cmtcfg.Config) func() (*cmttypes.GenesisDoc, error) {
+	return func() (*cmttypes.GenesisDoc, error) {
+		appGenesis, err := genutiltypes.AppGenesisFromFile(cfg.GenesisFile())
+		if err != nil {
+			return nil, err
+		}
+		return appGenesis.ToGenesisDoc()
+	}
 }

--- a/cmd/celestia-appd/cmd/start_command_standalone_test.go
+++ b/cmd/celestia-appd/cmd/start_command_standalone_test.go
@@ -1,0 +1,75 @@
+//go:build !multiplexer
+
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	cmtcfg "github.com/cometbft/cometbft/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetGenDocProvider(t *testing.T) {
+	// Create a temporary directory for the test
+	tempDir := t.TempDir()
+	configDir := filepath.Join(tempDir, "config")
+	require.NoError(t, os.MkdirAll(configDir, 0o755))
+
+	// Create a genesis file in SDK AppGenesis format (with InitialHeight as integer)
+	genesisFile := filepath.Join(configDir, "genesis.json")
+	// This is the format that the SDK's init command generates
+	genesisContent := `{
+		"app_name": "celestia-appd",
+		"app_version": "test",
+		"genesis_time": "2024-01-01T00:00:00Z",
+		"chain_id": "test-chain",
+		"initial_height": 1,
+		"app_hash": null,
+		"app_state": {},
+		"consensus": {
+			"validators": [],
+			"params": {
+				"block": {"max_bytes": "22020096", "max_gas": "-1"},
+				"evidence": {"max_age_num_blocks": "100000", "max_age_duration": "172800000000000", "max_bytes": "1048576"},
+				"validator": {"pub_key_types": ["ed25519"]},
+				"version": {"app": "0"},
+				"abci": {"vote_extensions_enable_height": "0"}
+			}
+		}
+	}`
+	require.NoError(t, os.WriteFile(genesisFile, []byte(genesisContent), 0o644))
+
+	// Create a CometBFT config pointing to the temp directory
+	cfg := cmtcfg.DefaultConfig()
+	cfg.SetRoot(tempDir)
+
+	// Get the genesis doc provider and call it
+	provider := getGenDocProvider(cfg)
+	genDoc, err := provider()
+
+	// Verify no error occurred (this would fail with the old DefaultGenesisDocProviderFunc
+	// because it can't handle InitialHeight as an integer)
+	require.NoError(t, err)
+
+	// Verify the genesis doc was parsed correctly
+	assert.Equal(t, "test-chain", genDoc.ChainID)
+	assert.Equal(t, int64(1), genDoc.InitialHeight)
+	assert.Equal(t, time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC), genDoc.GenesisTime)
+}
+
+func TestGetGenDocProvider_FileNotFound(t *testing.T) {
+	// Create a CometBFT config pointing to a non-existent directory
+	cfg := cmtcfg.DefaultConfig()
+	cfg.SetRoot("/non/existent/path")
+
+	// Get the genesis doc provider and call it
+	provider := getGenDocProvider(cfg)
+	_, err := provider()
+
+	// Verify an error occurred
+	assert.Error(t, err)
+}


### PR DESCRIPTION
## Summary
- Fixes the standalone binary startup failure caused by genesis file format mismatch
- Adds `getGenDocProvider` function that properly converts SDK's AppGenesis to CometBFT's GenesisDoc
- Adds unit tests to prevent regression

## Problem
The standalone binary was failing to start with:
```
error reading GenesisDoc: invalid 64-bit integer encoding "1", expected string
```

This occurred because `node.DefaultGenesisDocProviderFunc` reads the genesis file directly as CometBFT's format, but the SDK's init command generates an `AppGenesis` file where `InitialHeight` is an int64 (JSON integer) rather than a string.

## Solution
Added a custom `getGenDocProvider` function that:
1. Reads the genesis file using the SDK's `AppGenesisFromFile`
2. Converts it to CometBFT's `GenesisDoc` using `ToGenesisDoc()`

This matches the pattern used by the multiplexer binary in `multiplexer/internal/utils.go:GetGenDocProvider`.

## Test plan
- [x] Unit tests added for `getGenDocProvider`
- [x] `go test ./cmd/celestia-appd/...` passes
- [x] `make build-standalone` succeeds
- [x] `./scripts/single-node-fibre.sh` starts successfully (previously failed)

Closes #164

🤖 Generated with [Claude Code](https://claude.com/claude-code)