### PR TITLE
chore(deps): use the latest rsema1d commit

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/celestiaorg/go-square/v3 v3.0.2
 	github.com/celestiaorg/go-square/v4 v4.0.0-rc2
 	github.com/celestiaorg/nmt v0.24.2
-	github.com/celestiaorg/rsema1d v0.0.0-20251031140154-a36e18b9e940
+	github.com/celestiaorg/rsema1d v0.0.0-20260113121834-51e6165619b0
 	github.com/celestiaorg/rsmt2d v0.15.1
 	github.com/cometbft/cometbft v1.0.1
 	github.com/cometbft/cometbft-db v1.0.4

--- a/go.sum
+++ b/go.sum
@@ -805,8 +805,8 @@ github.com/celestiaorg/nmt v0.24.2 h1:LlpJSPOd6/Lw1Ig6HUhZuqiINHLka/ZSRTBzlNJpch
 github.com/celestiaorg/nmt v0.24.2/go.mod h1:vgLBpWBi8F5KLxTdXSwb7AU4NhiIQ1AQRGa+PzdcLEA=
 github.com/celestiaorg/reedsolomon v1.12.6-0.20250824224240-8b66bda83fd0 h1:nM6tHBLW1Uej4VKe6Zm3+kYnOrvcQ1Q4I1qFBIbC+EU=
 github.com/celestiaorg/reedsolomon v1.12.6-0.20250824224240-8b66bda83fd0/go.mod h1:39naxIQYdj/oxjNZVvWvhRreh3uguAq4v6Ke7mI9cDI=
-github.com/celestiaorg/rsema1d v0.0.0-20251031140154-a36e18b9e940 h1:YeC/5Lx3A06Ggvc0aKYZjnUMvbBJD5p2okNddQnIxw0=
-github.com/celestiaorg/rsema1d v0.0.0-20251031140154-a36e18b9e940/go.mod h1:pDqRBQaFbwdX3AUoPLAhucV+MUSm701fOMGxZZwvML0=
+github.com/celestiaorg/rsema1d v0.0.0-20260113121834-51e6165619b0 h1:G7ctPrCA0y6zIN2CtWNz8Z37c1fwqDRj8GvX+5/PyFw=
+github.com/celestiaorg/rsema1d v0.0.0-20260113121834-51e6165619b0/go.mod h1:WtDhTrN17IA6ZBLEIZsXv+IAQJD4grchKeodmLbjt+g=
 github.com/celestiaorg/rsmt2d v0.15.1 h1:NF4D0LX501oDjw00RoJrTUrMHrO+Kv0LewL0FKQU7hg=
 github.com/celestiaorg/rsmt2d v0.15.1/go.mod h1:WKkpXoD1foHn4qgFx6GNoz36Wm0fbCh29ze4rA7ZwCs=
 github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=

--- a/test/docker-e2e/go.mod
+++ b/test/docker-e2e/go.mod
@@ -83,7 +83,7 @@ require (
 	github.com/celestiaorg/merkletree v0.0.0-20210714075610-a84dc3ddbbe4 // indirect
 	github.com/celestiaorg/nmt v0.24.2 // indirect
 	github.com/celestiaorg/reedsolomon v1.12.6-0.20250824224240-8b66bda83fd0 // indirect
-	github.com/celestiaorg/rsema1d v0.0.0-20251031140154-a36e18b9e940 // indirect
+	github.com/celestiaorg/rsema1d v0.0.0-20260113121834-51e6165619b0 // indirect
 	github.com/celestiaorg/rsmt2d v0.15.1 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect

--- a/test/docker-e2e/go.sum
+++ b/test/docker-e2e/go.sum
@@ -796,8 +796,8 @@ github.com/celestiaorg/nmt v0.24.2 h1:LlpJSPOd6/Lw1Ig6HUhZuqiINHLka/ZSRTBzlNJpch
 github.com/celestiaorg/nmt v0.24.2/go.mod h1:vgLBpWBi8F5KLxTdXSwb7AU4NhiIQ1AQRGa+PzdcLEA=
 github.com/celestiaorg/reedsolomon v1.12.6-0.20250824224240-8b66bda83fd0 h1:nM6tHBLW1Uej4VKe6Zm3+kYnOrvcQ1Q4I1qFBIbC+EU=
 github.com/celestiaorg/reedsolomon v1.12.6-0.20250824224240-8b66bda83fd0/go.mod h1:39naxIQYdj/oxjNZVvWvhRreh3uguAq4v6Ke7mI9cDI=
-github.com/celestiaorg/rsema1d v0.0.0-20251031140154-a36e18b9e940 h1:YeC/5Lx3A06Ggvc0aKYZjnUMvbBJD5p2okNddQnIxw0=
-github.com/celestiaorg/rsema1d v0.0.0-20251031140154-a36e18b9e940/go.mod h1:pDqRBQaFbwdX3AUoPLAhucV+MUSm701fOMGxZZwvML0=
+github.com/celestiaorg/rsema1d v0.0.0-20260113121834-51e6165619b0 h1:G7ctPrCA0y6zIN2CtWNz8Z37c1fwqDRj8GvX+5/PyFw=
+github.com/celestiaorg/rsema1d v0.0.0-20260113121834-51e6165619b0/go.mod h1:WtDhTrN17IA6ZBLEIZsXv+IAQJD4grchKeodmLbjt+g=
 github.com/celestiaorg/rsmt2d v0.15.1 h1:NF4D0LX501oDjw00RoJrTUrMHrO+Kv0LewL0FKQU7hg=
 github.com/celestiaorg/rsmt2d v0.15.1/go.mod h1:WKkpXoD1foHn4qgFx6GNoz36Wm0fbCh29ze4rA7ZwCs=
 github.com/celestiaorg/tastora v0.5.1 h1:lFaJ6q8jUyK7iUL0hBwbS93DMp5jM1kDEp2EiAPlm4w=


### PR DESCRIPTION
## Overview

After the rsema1d tree was updated, go.mod was pointing to a commit that was overwritten. This PR updates to the latest commit