### PR TITLE
fix: signatures order when submitting pff

### DIFF
--- a/fibre/client_upload.go
+++ b/fibre/client_upload.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/hex"
 	"fmt"
+	"sync"
 	"sync/atomic"
 
 	"github.com/celestiaorg/celestia-app-fibre/v6/fibre/validator"
@@ -80,6 +81,9 @@ func (c *Client) Upload(ctx context.Context, ns share.Namespace, blob *Blob) (re
 	requests := makeUploadRequests(shardMap, promise.ToProto(), blob.RLCCoeffs())
 	sigSet := valSet.NewSignatureSet(c.cfg.SafetyThreshold, validatorSignBytes)
 
+	// concurrent-safe map to track validator address → signature for ordering
+	var sigMap sync.Map
+
 	c.log.DebugContext(ctx, "initiating blob upload",
 		"promise_hash", hex.EncodeToString(promiseHash),
 		"promise_height", promise.Height,
@@ -90,31 +94,39 @@ func (c *Client) Upload(ctx context.Context, ns share.Namespace, blob *Blob) (re
 	)
 
 	// 3) upload data
-	if err = c.uploadShards(ctx, requests, blob, sigSet); err != nil {
+	if err = c.uploadShards(ctx, requests, blob, sigSet, &sigMap); err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, "failed to upload")
 		return result, err
 	}
 
 	// 5) collect signatures
-	sigs, err := sigSet.Signatures()
-	if err != nil {
+	if _, err := sigSet.Signatures(); err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, "failed to collect signatures")
 		return result, err
+	}
+
+	// Build ordered signatures matching the validator set order.
+	// Validators that didn't sign get nil entries.
+	orderedSigs := make([][]byte, len(valSet.Validators))
+	for i, val := range valSet.Validators {
+		if sig, ok := sigMap.Load(val.Address.String()); ok {
+			orderedSigs[i] = sig.([]byte)
+		}
 	}
 
 	c.log.DebugContext(ctx, "blob upload completed",
 		"promise_hash", hex.EncodeToString(promiseHash),
 		"blob_commitment", promise.Commitment.String(),
 		"upload_size", promise.UploadSize,
-		"signatures_collected", len(sigs),
+		"signatures_collected", len(orderedSigs),
 	)
 
 	span.SetStatus(codes.Ok, "")
 	return SignedPaymentPromise{
 		PaymentPromise:      promise,
-		ValidatorSignatures: sigs,
+		ValidatorSignatures: orderedSigs,
 	}, nil
 }
 
@@ -179,6 +191,7 @@ func (c *Client) uploadTo(
 	req *types.UploadShardRequest,
 	blob *Blob,
 	sigSet *validator.SignatureSet,
+	sigMap *sync.Map,
 ) bool {
 	ctx, cancel := context.WithCancel(ctx) // GRPC calls require context cancelling upon completion
 	defer cancel()
@@ -249,6 +262,9 @@ func (c *Client) uploadTo(
 		return false
 	}
 
+	// track address → signature for ordering later
+	sigMap.Store(val.Address.String(), signature)
+
 	log.DebugContext(ctx, "successfully uploaded to validator")
 	span.AddEvent("signature_verified")
 	span.SetStatus(codes.Ok, "")
@@ -263,6 +279,7 @@ func (c *Client) uploadShards(
 	requests map[*core.Validator]*types.UploadShardRequest,
 	blob *Blob,
 	sigSet *validator.SignatureSet,
+	sigMap *sync.Map,
 ) error {
 	var (
 		responses            atomic.Uint32         // tracks finished responses
@@ -297,7 +314,7 @@ func (c *Client) uploadShards(
 				c.closeWg.Done()
 			}()
 
-			isDone := c.uploadTo(ctx, val, req, blob, sigSet)
+			isDone := c.uploadTo(ctx, val, req, blob, sigSet, sigMap)
 			if isDone && sigsCollectedOnce.CompareAndSwap(false, true) {
 				close(sigsCollectedCh)
 			}

--- a/x/fibre/types/msgs.go
+++ b/x/fibre/types/msgs.go
@@ -114,12 +114,6 @@ func (msg *MsgPayForFibre) ValidateBasic() error {
 		return errorsmod.Wrap(sdkerrors.ErrInvalidRequest, "must have at least one validator signature")
 	}
 
-	for i, signature := range msg.ValidatorSignatures {
-		if len(signature) == 0 {
-			return errorsmod.Wrapf(sdkerrors.ErrInvalidRequest, "validator signature at index %d cannot be empty", i)
-		}
-	}
-
 	return nil
 }
 

--- a/x/fibre/types/msgs_test.go
+++ b/x/fibre/types/msgs_test.go
@@ -398,7 +398,7 @@ func TestMsgPayForFibreValidateBasic(t *testing.T) {
 				PaymentPromise:      paymentPromise,
 				ValidatorSignatures: [][]byte{[]byte("sig1"), {}},
 			},
-			wantErr: sdkerrors.ErrInvalidRequest,
+			wantErr: nil,
 		},
 	}
 


### PR DESCRIPTION
## Overview

This PR fixes an issue with signatures order. When submitting a PFF, we provide the signatures in order, however, if some signatures are missing (given we send the PFF the moment we have 2/3rd), then the validation in the state machine can be invalid given it expects the signatures to be in the order of the validator set.


Note: Claude generated