### PR TITLE
chore: use the gas price estimation endpoint in txclient

### DIFF
--- a/pkg/user/tx_client.go
+++ b/pkg/user/tx_client.go
@@ -483,7 +483,11 @@ func (client *TxClient) BroadcastTx(ctx context.Context, msgs []sdktypes.Msg, op
 	}
 
 	if !hasUserSetFee {
-		fee := int64(math.Ceil(appconsts.DefaultMinGasPrice * float64(gasLimit)))
+		gasPriceResp, err := client.gasEstimationClient.EstimateGasPrice(ctx, &gasestimation.EstimateGasPriceRequest{})
+		if err != nil {
+			return nil, err
+		}
+		fee := int64(math.Ceil(gasPriceResp.EstimatedGasPrice * float64(gasLimit)))
 		txBuilder.SetFeeAmount(sdktypes.NewCoins(sdktypes.NewCoin(appconsts.BondDenom, sdkmath.NewInt(fee))))
 	}
 


### PR DESCRIPTION
## Overview

WHen the chain is full, I noticed sometimes fibre transactions taking a bit of time to be included. This PR helps with that by using the gas estimation endpoint instead of the hardcoded min value