### PR TITLE
chore: reduce the fibre upload log to debug level

### DIFF
--- a/fibre/server_upload.go
+++ b/fibre/server_upload.go
@@ -80,7 +80,7 @@ func (s *Server) UploadShard(ctx context.Context, req *types.UploadShardRequest)
 	}
 	span.AddEvent("signature_generated")
 
-	log.InfoContext(ctx, "successful upload",
+	log.DebugContext(ctx, "successful upload",
 		"upload_size", promise.UploadSize,
 		"rows_count", len(req.Shard.Rows),
 		"row_size", len(req.Shard.Rows[0].Data),


### PR DESCRIPTION
## Overview

When you spam fibre, the transactions uploads logs clutter the validator logs. This PR reduces their log level to debug. IMO should be even trace level but it's not implemented. At some point we might want to switch to comet's logger or cosmos-sdk given we implemented trace level there.