### PR TITLE
chore: copy the fibre-txsim binary to /bin in talis

### DIFF
--- a/tools/talis/scripts/validator_init.sh
+++ b/tools/talis/scripts/validator_init.sh
@@ -86,6 +86,7 @@ parsed_hostname=$(echo $hostname | awk -F'-' '{print $1 "-" $2}')
 cp payload/build/celestia-appd /bin/celestia-appd
 cp payload/build/txsim /bin/txsim
 cp payload/build/latency-monitor /bin/latency-monitor
+cp payload/build/fibre-txsim /bin/fibre-txsim
 
 cd $HOME
 


### PR DESCRIPTION
## Overview

I forgot to stage this in the previous Talis PR