### PR TITLE
docs: update README to point to celestia-app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,32 +1,9 @@
 # celestia-app-fibre
 
-celestia-app-fibre is a fork of [celestia-app](https://github.com/celestiaorg/celestia-app) that adds support for Fibre DA.
-
-The canonical branch in this repo is `feature/fibre`.
-
-This repo is temporary and will eventually be merged into celestia-app.
-
-## Usage
-
-Build the binary with fibre:
-
-```bash
-make install
-```
-
-Start a local single node devnet with Fibre DA enabled:
-
-```bash
-./scripts/single-node-fibre.sh
-```
-
-In a separate terminal, start submitting Fibre blobs:
-
-```bash
-./scripts/submit-fibre-blobs.sh
-```
+> **This repository has been archived.** The contents of this repo have been merged into [celestia-app](https://github.com/celestiaorg/celestia-app). Please refer to celestia-app for the latest code and development.
 
 ## Links
 
-- <https://github.com/celestiaorg/fibre-da-spec>
-- <https://github.com/celestiaorg/rsema1d>
+- [celestia-app](https://github.com/celestiaorg/celestia-app)
+- [fibre-da-spec](https://github.com/celestiaorg/fibre-da-spec)
+- [rsema1d](https://github.com/celestiaorg/rsema1d)


### PR DESCRIPTION
## Summary

- Updates the README to inform readers that this repo's contents have been merged into [celestia-app](https://github.com/celestiaorg/celestia-app)
- Removes outdated usage instructions since development continues in celestia-app
- Prepares the repo for being marked as a public archive

## Test plan

- [ ] Verify the README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)